### PR TITLE
Fix removeConstraint operation

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -332,7 +332,10 @@ self.onmessage = (e) => {
       break
     }
     case 'removeConstraint':
-      world.removeConstraint(uuid)
+      const constraint = world.constraints.find(({ uuid: thisId }) => thisId === uuid)
+      if (constraint) {
+        world.removeConstraint(uuid)
+      }
       break
 
     case 'enableConstraint':

--- a/src/worker.js
+++ b/src/worker.js
@@ -334,7 +334,7 @@ self.onmessage = (e) => {
     case 'removeConstraint':
       const constraint = world.constraints.find(({ uuid: thisId }) => thisId === uuid)
       if (constraint) {
-        world.removeConstraint(uuid)
+        world.removeConstraint(constraint)
       }
       break
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -332,10 +332,7 @@ self.onmessage = (e) => {
       break
     }
     case 'removeConstraint':
-      const constraint = world.constraints.find(({ uuid: thisId }) => thisId === uuid)
-      if (constraint) {
-        world.removeConstraint(constraint)
-      }
+      world.constraints.filter(({ uuid: thisId }) => thisId === uuid).map((c) => world.removeConstraint(c))
       break
 
     case 'enableConstraint':


### PR DESCRIPTION
cannon.js `removeConstraint` function accepts Constraint object as an argument (http://schteppe.github.io/cannon.js/docs/files/src_world_World.js.html#l274) and currently use-cannon tries to pass uuid which doesn't work. this pr fixes that.

example of it not working: https://codesandbox.io/s/loving-euclid-7398e?file=/src/App.tsx