### PR TITLE
improve usage of collide event

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -300,16 +300,33 @@ type BodyProps = AtomicProps & {
   onCollide?: (e: Event) => void
 }
 
-type Event = {
+type Event = RayhitEvent | CollideEvent
+type CollideEvent = {
   op: string
-  type: string
+  type: 'collide'
   body: THREE.Object3D
   target: THREE.Object3D
   contact: {
-    ni: number[]
-    ri: number[]
-    rj: number[]
+    // the world position of the point of contact
+    contactPoint: number[]
+    // the normal of the collision on the surface of
+    // the colliding body
+    contactNormal: number[]
+    // velocity of impact along the contact normal
     impactVelocity: number
+    // a unique ID for each contact event
+    id: string
+    // these are lower-level properties from cannon:
+    // bi: one of the bodies involved in contact
+    bi: THREE.Object3D
+    // bj: the other body involved in contact
+    bj: THREE.Object3D
+    // ni: normal of contact relative to bi
+    ni: number[]
+    // ri: the point of contact relative to bi
+    ri: number[]
+    // rj: the point of contact relative to bj
+    rj: number[]
   }
   collisionFilters: {
     bodyFilterGroup: number
@@ -317,6 +334,12 @@ type Event = {
     targetFilterGroup: number
     targetFilterMask: number
   }
+}
+type RayhitEvent = {
+  op: string
+  type: 'rayhit'
+  body: THREE.Object3D
+  target: THREE.Object3D
 }
 
 type PlaneProps = BodyProps & {}

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -42,10 +42,17 @@ export type WorkerCollideEvent = {
     target: string
     body: string
     contact: {
+      id: string
       ni: number[]
       ri: number[]
       rj: number[]
       impactVelocity: number
+      bi: string
+      bj: string
+      /** Contact point in world space */
+      contactPoint: number[]
+      /** Normal of the contact, relative to the colliding body */
+      contactNormal: number[]
     }
     collisionFilters: {
       bodyFilterGroup: number
@@ -158,6 +165,11 @@ export default function Provider({
                 ...e.data,
                 target: refs[e.data.target],
                 body: refs[e.data.body],
+                contact: {
+                  ...e.data.contact,
+                  bi: refs[e.data.contact.bi],
+                  bj: refs[e.data.contact.bj],
+                },
               })
               break
             case 'rayhit':

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -193,7 +193,6 @@ export default function Provider({
               })
               break
             case 'collideBegin':
-              console.log(e)
               if (events[e.data.bodyA]) {
                 events[e.data.bodyA]({
                   op: 'event',

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -86,7 +86,27 @@ export type WorkerRayhitEvent = {
     shouldStop: boolean
   }
 }
-type WorkerEventMessage = WorkerCollideEvent | WorkerRayhitEvent
+export type WorkerCollideBeginEvent = {
+  data: {
+    op: 'event'
+    type: 'collideBegin'
+    bodyA: string
+    bodyB: string
+  }
+}
+export type WorkerCollideEndEvent = {
+  data: {
+    op: 'event'
+    type: 'collideEnd'
+    bodyA: string
+    bodyB: string
+  }
+}
+type WorkerEventMessage =
+  | WorkerCollideEvent
+  | WorkerRayhitEvent
+  | WorkerCollideBeginEvent
+  | WorkerCollideEndEvent
 type IncomingWorkerMessage = WorkerFrameMessage | WorkerEventMessage
 
 export default function Provider({
@@ -171,6 +191,43 @@ export default function Provider({
                   bj: refs[e.data.contact.bj],
                 },
               })
+              break
+            case 'collideBegin':
+              console.log(e)
+              if (events[e.data.bodyA]) {
+                events[e.data.bodyA]({
+                  op: 'event',
+                  type: 'collideBegin',
+                  target: refs[e.data.bodyA],
+                  body: refs[e.data.bodyB],
+                })
+              }
+              if (events[e.data.bodyB]) {
+                events[e.data.bodyB]({
+                  op: 'event',
+                  type: 'collideBegin',
+                  target: refs[e.data.bodyB],
+                  body: refs[e.data.bodyA],
+                })
+              }
+              break
+            case 'collideEnd':
+              if (events[e.data.bodyA]) {
+                events[e.data.bodyA]({
+                  op: 'event',
+                  type: 'collideEnd',
+                  target: refs[e.data.bodyA],
+                  body: refs[e.data.bodyB],
+                })
+              }
+              if (events[e.data.bodyB]) {
+                events[e.data.bodyB]({
+                  op: 'event',
+                  type: 'collideEnd',
+                  target: refs[e.data.bodyB],
+                  body: refs[e.data.bodyA],
+                })
+              }
               break
             case 'rayhit':
               events[e.data.ray.uuid]({

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -15,8 +15,20 @@ export type CollideEvent = Omit<WorkerCollideEvent['data'], 'body' | 'target' | 
     bj: Object3D
   }
 }
+export type CollideBeginEvent = {
+  op: 'event'
+  type: 'collideBegin'
+  target: Object3D
+  body: Object3D
+}
+export type CollideEndEvent = {
+  op: 'event'
+  type: 'collideEnd'
+  target: Object3D
+  body: Object3D
+}
 export type RayhitEvent = Omit<WorkerRayhitEvent['data'], 'body'> & { body: Object3D | null }
-export type Event = RayhitEvent | CollideEvent
+export type Event = RayhitEvent | CollideEvent | CollideBeginEvent | CollideEndEvent
 export type Events = { [uuid: string]: (e: Event) => void }
 export type Subscriptions = {
   [id: string]: (value: AtomicProps[keyof AtomicProps] | number[]) => void

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -6,9 +6,17 @@ import { isJSDocNullableType } from 'typescript'
 
 export type Buffers = { positions: Float32Array; quaternions: Float32Array }
 export type Refs = { [uuid: string]: Object3D }
-export type Event =
-  | (Omit<WorkerRayhitEvent['data'], 'body'> & { body: Object3D | null })
-  | (Omit<WorkerCollideEvent['data'], 'body' | 'target'> & { body: Object3D; target: Object3D })
+type WorkerContact = WorkerCollideEvent['data']['contact']
+export type CollideEvent = Omit<WorkerCollideEvent['data'], 'body' | 'target' | 'contact'> & {
+  body: Object3D
+  target: Object3D
+  contact: Omit<WorkerContact, 'bi' | 'bj'> & {
+    bi: Object3D
+    bj: Object3D
+  }
+}
+export type RayhitEvent = Omit<WorkerRayhitEvent['data'], 'body'> & { body: Object3D | null }
+export type Event = RayhitEvent | CollideEvent
 export type Events = { [uuid: string]: (e: Event) => void }
 export type Subscriptions = {
   [id: string]: (value: AtomicProps[keyof AtomicProps] | number[]) => void

--- a/src/worker.js
+++ b/src/worker.js
@@ -46,6 +46,14 @@ function syncBodies() {
   state.bodies = state.world.bodies.reduce((acc, body) => ({ ...acc, [body.uuid]: body }), {})
 }
 
+function emitBeginContact({ bodyA, bodyB }) {
+  self.postMessage({ op: 'event', type: 'collideBegin', bodyA: bodyA.uuid, bodyB: bodyB.uuid })
+}
+
+function emitEndContact({ bodyA, bodyB }) {
+  self.postMessage({ op: 'event', type: 'collideEnd', bodyA: bodyA.uuid, bodyB: bodyB.uuid })
+}
+
 self.onmessage = (e) => {
   const { op, uuid, type, positions, quaternions, props } = e.data
 
@@ -68,6 +76,8 @@ self.onmessage = (e) => {
       state.world.solver.iterations = iterations
       state.world.broadphase = new (broadphases[broadphase + 'Broadphase'] || NaiveBroadphase)(state.world)
       state.world.broadphase.axisIndex = axisIndex === undefined || axisIndex === null ? 0 : axisIndex
+      world.addEventListener('beginContact', emitBeginContact)
+      world.addEventListener('endContact', emitEndContact)
       Object.assign(state.world.defaultContactMaterial, defaultContactMaterial)
       state.config.step = step
       break

--- a/src/worker.js
+++ b/src/worker.js
@@ -129,7 +129,10 @@ self.onmessage = (e) => {
 
         if (props[i].onCollide)
           body.addEventListener('collide', ({ type, body, target, contact }) => {
-            const { ni, ri, rj } = contact
+            const { ni, ri, rj, bi, bj, id } = contact
+            const contactPoint = bi.position.vadd(ri)
+            const biIsBody = bi === body
+            const contactNormal = bi === body ? ni : ni.scale(-1)
             self.postMessage({
               op: 'event',
               type,
@@ -139,7 +142,14 @@ self.onmessage = (e) => {
                 ni: ni.toArray(),
                 ri: ri.toArray(),
                 rj: rj.toArray(),
+                bi: bi.uuid,
+                bj: bj.uuid,
                 impactVelocity: contact.getImpactVelocityAlongNormal(),
+                // World position of the contact
+                contactPoint: contactPoint.toArray(),
+                // Normal of the contact, relative to the colliding body
+                contactNormal: contactNormal.toArray(),
+                id,
               },
               collisionFilters: {
                 bodyFilterGroup: body.collisionFilterGroup,


### PR DESCRIPTION
Hello there! I've been looking into building games with React, and I love the fact that this library runs the physics engine in a worker. However, I found that even some basic game ideas require a more fleshed-out understanding of contact events than is currently provided, both in documentation and provided values.

This is an initial attempt at improving the data provided from the collide event so it can be used more easily. The main questions I wanted to answer:

1. What was the point of contact?
2. What was the normal of contact on the surface of the object this body collided with?
3. When did a contact start? When did it end?

To wit I added two new callbacks to body hooks:

* `onCollideStart`: called with `{ body }`, the colliding body
* `onCollideEnd`: also called with `{ body }`, the colliding body

This is pretty much all the info Cannon provides with its corresponding start/end events, but it's enough to work with. At least with the identity of the other body, you can look up the collision and flag it as "beginning" or "ended."

Here's how I'm currently using my fork with local testing (unoptimized, rough sketch):

```tsx

type ContactEvent = CollideEvent & { beginning: boolean; ended: boolean };

export type ContactsState = {
  active: ContactEvent[];
};

export const useContacts = () => {
  // have to collect these separately since they come from events
  // which might fire at any time during the frame - so I collect them
  // here and then copy them to the main collection at the start of each frame.
  const [collectedContacts] = React.useState<{
    active: ContactEvent[];
    beginIds: Set<string>;
    endedIds: Set<string>;
  }>(() => ({
    active: [],
    beginIds: new Set<string>(),
    endedIds: new Set<string>(),
  }));
  const [contacts] = React.useState<ContactsState>(() => ({
    active: [],
  }));

  const onCollide = React.useCallback(
    (e: CollideEvent) => {
      collectedContacts.active.push({
        ...e,
        beginning: false,
        ended: false,
      });
    },
    [collectedContacts],
  );
  const onCollideBegin = React.useCallback(
    (e: CollideBeginEvent) => {
      collectedContacts.beginIds.add(e.body.uuid);
    },
    [collectedContacts],
  );
  const onCollideEnd = React.useCallback(
    (e: CollideEndEvent) => {
      collectedContacts.endedIds.add(e.body.uuid);
    },
    [collectedContacts],
  );

  useFrame(() => {
    contacts.active = collectedContacts.active.reduce((list, contact) => {
      // drop ended contacts
      if (contact.ended) {
        return list;
      }
      if (collectedContacts.endedIds.has(contact.body.uuid)) {
        contact.ended = true;
      }
      if (collectedContacts.beginIds.has(contact.body.uuid)) {
        contact.beginning = true;
      } else {
        contact.beginning = false;
      }
      list.push(contact);
      return list;
    }, new Array<ContactEvent>());
    // copying back to collected - this keeps active collisions
    // "alive" since onCollide is really only called once per collision.
    // The idea is to continually provide the collision during its lifecycle
    // to code that cares about it.
    collectedContacts.active = contacts.active;
    collectedContacts.beginIds = new Set<string>();
    collectedContacts.endedIds = new Set<string>();
  // frame priority is set very low, so this happens before other frame handlers
  }, -100);

  return [
    contacts,
    {
      onCollide,
      onCollideBegin,
      onCollideEnd,
    },
  ] as const;
};

// In a component
const [contacts, handlers] = useContacts();
const [ref] = useSphere({ mass: 1, ...handlers });

useFrame(() => {
  // now I can use contacts.active here to check active collisions,
  // new collisions vs. ended ones, etc.
});
```

This is still quite a bit of code to add on top of the library, though, so maybe there would be room to expand this library's usage to manage these flags for you? That is, if you find this addition worthwhile at all. I know this library seems a bit more casual in terms of usage and maybe this level of complexity isn't something you want to introduce.