### PR TITLE
implement userData

### DIFF
--- a/examples/src/demos/RaycastVehicle/Chassis.js
+++ b/examples/src/demos/RaycastVehicle/Chassis.js
@@ -30,6 +30,11 @@ function Beetle(props) {
 
 useGLTF.preload('/Beetle.glb')
 
+const onCollide = (e) => {
+  // the other body:
+  console.log('bonk!', e.body.userData)
+}
+
 // The vehicle chassis
 const Chassis = forwardRef((props, ref) => {
   const boxSize = [1.7, 1, 4] // roughly the cars's visual dimensions
@@ -40,7 +45,11 @@ const Chassis = forwardRef((props, ref) => {
       angularVelocity: props.angularVelocity,
       allowSleep: false,
       args: boxSize,
-      onCollide: (e) => console.log(`bonk`),
+      onCollide: onCollide,
+      userData: {
+        // define you custom application reference here
+        id: 'vehicle-chassis',
+      },
       ...props,
     }),
     ref

--- a/examples/src/demos/RaycastVehicle/index.js
+++ b/examples/src/demos/RaycastVehicle/index.js
@@ -54,16 +54,16 @@ const VehicleScene = () => {
         <ambientLight intensity={0.1} />
         <spotLight position={[10, 10, 10]} angle={0.3} intensity={1} castShadow penumbra={0.5} />
         <Physics broadphase="SAP" {...defaultContactMaterial} allowSleep>
-          <Plane rotation={[-Math.PI / 2, 0, 0]} />
+          <Plane rotation={[-Math.PI / 2, 0, 0]} userData={{ id: 'floor' }} />
           <Vehicle
             position={[0, 5, 0]}
             rotation={[0, -Math.PI / 4, 0]}
             angularVelocity={[0, 0.5, 0]} // to get you rolling
             wheelRadius={0.3}
           />
-          <Pillar position={[-5, 2.5, -5]} />
-          <Pillar position={[0, 2.5, -5]} />
-          <Pillar position={[5, 2.5, -5]} />
+          <Pillar position={[-5, 2.5, -5]} userData={{ id: 'pillar-1' }} />
+          <Pillar position={[0, 2.5, -5]} userData={{ id: 'pillar-2' }} />
+          <Pillar position={[5, 2.5, -5]} userData={{ id: 'pillar-3' }} />
         </Physics>
       </Canvas>
       <div

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -17,6 +17,7 @@ export type AtomicProps = {
   collisionFilterMask?: number
   collisionResponse?: number
   fixedRotation?: boolean
+  userData?: object
 }
 
 export type BodyProps = AtomicProps & {
@@ -141,6 +142,7 @@ const temp = new THREE.Object3D()
 
 function prepare(object: THREE.Object3D, props: BodyProps, argFn: ArgFn) {
   props.args = argFn(props.args)
+  object.userData = props.userData || {}
   object.position.set(...((props.position || [0, 0, 0]) as [number, number, number]))
   object.rotation.set(...((props.rotation || [0, 0, 0]) as [number, number, number]))
   return props
@@ -272,6 +274,7 @@ function useBody(
         collisionFilterMask: makeAtomic('collisionFilterMask', index),
         collisionResponse: makeAtomic('collisionResponse', index),
         fixedRotation: makeAtomic('fixedRotation', index),
+        userData: makeAtomic('userData', index),
         // Apply functions
         applyForce(force: number[], worldPoint: number[]) {
           post('applyForce', index, [force, worldPoint])


### PR DESCRIPTION
Hello Mike,

I was reading through the discussions this morning and came across [an issue](https://github.com/pmndrs/use-cannon/discussions/130) I had been struggling with myself. 

So I thought: why not use the [userData attribute](https://threejs.org/docs/#api/en/core/Object3D.userData) that has been around in three for years ?

The problem was although the attribute can be set, it would not get returned in the onCollide handler's body/target properties. This PR fixes that.

Note:: this is just a proposition, would love to hear your opinion on it !

PS: nice touch with the WV(sic) model 😆 
