### PR TITLE
Make the world stepping framerate independent

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -68,6 +68,7 @@ function syncBodies() {
   bodies = world.bodies.reduce((acc, body) => ({ ...acc, [body.uuid]: body }), {})
 }
 
+let lastCallTime
 self.onmessage = (e) => {
   const { op, uuid, type, positions, quaternions, props } = e.data
 
@@ -95,7 +96,15 @@ self.onmessage = (e) => {
       break
     }
     case 'step': {
-      world.step(config.step)
+      const now = performance.now() / 1000
+      if (!lastCallTime) {
+        world.step(config.step)
+      } else {
+        const timeSinceLastCall = now - lastCallTime
+        world.step(config.step, timeSinceLastCall)
+      }
+      lastCallTime = now
+
       const numberOfBodies = world.bodies.length
       for (let i = 0; i < numberOfBodies; i++) {
         let b = world.bodies[i],


### PR DESCRIPTION
Some days ago a user reported that the world stepping is different in the Oculus browser.

![image](https://user-images.githubusercontent.com/7217420/107937894-dd0e4c00-6f84-11eb-89f2-0759d4e7273d.png)

This is because, as he pointed out, the requestAnimationFrame in the Oculus browser runs at 90fps instead of 60. Since `world.step()` was called in the requestAnimationFrame, the world stepping is a little bit faster.

This PR makes the world stepping **framerate independent**. Basically it takes into consideration the last time the step function was called and adapts otherwise.

The implementation was originally done by schteppe for cannon.js following the article [Fix your timestep!](https://gafferongames.com/post/fix_your_timestep/), some bugs were fixed in cannon-es in https://github.com/pmndrs/cannon-es/pull/40.

After this PR, the simulation should run at the same speed in both normal browsers and the Oculus browser.