### PR TITLE
disable source maps in production build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default [
     output: { dir: 'dist', format: 'esm' },
     external,
     plugins: [
-      worker({ targetPlatform: 'browser', pattern: /.*\/worker$/ }),
+      worker({ targetPlatform: 'browser', pattern: /.*\/worker$/, sourcemap: false }),
       resolve({ extensions }),
       babel(getBabelOptions({ useESModules: true }, '>1%, not dead, not ie 11, not op_mini all')),
       terser(),
@@ -35,7 +35,7 @@ export default [
     output: { dir: 'dist/debug', format: 'esm' },
     external,
     plugins: [
-      worker({ targetPlatform: 'browser', pattern: /.*\/worker$/ }),
+      worker({ targetPlatform: 'browser', pattern: /.*\/worker$/, sourcemap: true }),
       resolve({ extensions }),
       babel(getBabelOptions({ useESModules: true }, '>1%, not dead, not ie 11, not op_mini all')),
     ],


### PR DESCRIPTION
`rollup-plugin-web-worker-loader` generates source maps on default for worker code
https://github.com/darionco/rollup-plugin-web-worker-loader/pull/45

and source maps dramatically increase package size

```
size with sourcemaps — 914K
size without         — 164K
```

so I disable them in production and enable for debug bundle 