### PR TITLE
Add Spring setters

### DIFF
--- a/examples/src/demos/Constraints.js
+++ b/examples/src/demos/Constraints.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { Physics, useSphere, useBox, useSpring } from '@react-three/cannon'
 
@@ -35,12 +35,18 @@ const Ball = React.forwardRef((props, ref) => {
 const BoxAndBall = () => {
   const box = useRef()
   const ball = useRef()
-  useSpring(box, ball, { restLength: 1, stiffness: 100, damping: 1 })
+
+  const [, , api] = useSpring(box, ball, { restLength: 2, stiffness: 100, damping: 1 })
+
+  const [isDown, setIsDown] = useState(false)
+
+  useEffect(() => api.setRestLength(isDown ? 0 : 2), [isDown])
+
   return (
-    <>
+    <group onPointerDown={() => setIsDown(true)} onPointerUp={() => setIsDown(false)}>
       <Box ref={box} position={[1, 0, 0]} />
       <Ball ref={ball} position={[-1, 0, 0]} />
-    </>
+    </group>
   )
 }
 

--- a/readme.md
+++ b/readme.md
@@ -203,6 +203,16 @@ type ConstraintApi = [
     disable: () => void
   }
 ]
+
+type SpringApi = [
+  React.MutableRefObject<THREE.Object3D | undefined>,
+  React.MutableRefObject<THREE.Object3D | undefined>,
+  {
+    setStiffness: (value: number) => void
+    setRestLength: (value: number) => void
+    setDamping: (value: number) => void
+  }
+]
 ```
 
 ### Props

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -355,6 +355,16 @@ type ConstraintApi = [
   }
 ]
 
+type SpringApi = [
+  React.MutableRefObject<THREE.Object3D | undefined>,
+  React.MutableRefObject<THREE.Object3D | undefined>,
+  {
+    setStiffness: (value: number) => void
+    setRestLength: (value: number) => void
+    setDamping: (value: number) => void
+  }
+]
+
 function useConstraint(
   type: ConstraintTypes,
   bodyA: React.MutableRefObject<THREE.Object3D | undefined>,
@@ -439,7 +449,7 @@ export function useSpring(
   bodyB: React.MutableRefObject<THREE.Object3D | undefined>,
   optns: SpringOptns,
   deps: any[] = []
-) {
+): SpringApi {
   const { worker, events } = useContext(context)
   const [uuid] = useState(() => THREE.MathUtils.generateUUID())
 
@@ -463,7 +473,16 @@ export function useSpring(
     }
   }, deps)
 
-  return [bodyA, bodyB]
+  const api = useMemo(
+    () => ({
+      setStiffness: (value: number) => worker.postMessage({ op: 'setSpringStiffness', props: value, uuid }),
+      setRestLength: (value: number) => worker.postMessage({ op: 'setSpringRestLength', props: value, uuid }),
+      setDamping: (value: number) => worker.postMessage({ op: 'setSpringDamping', props: value, uuid }),
+    }),
+    deps
+  )
+
+  return [bodyA, bodyB, api]
 }
 
 type RayOptns = Omit<RayOptions, 'mode' | 'from' | 'to' | 'result' | 'callback'> & {

--- a/src/worker.js
+++ b/src/worker.js
@@ -29,6 +29,7 @@ import {
 let bodies = {}
 const vehicles = {}
 const springs = {}
+const springInstances = {}
 const rays = {}
 const world = new World()
 const config = { step: 1 / 60 }
@@ -393,9 +394,22 @@ self.onmessage = (e) => {
       let postStepSpring = (e) => spring.applyForce()
 
       springs[uuid] = postStepSpring
+      springInstances[uuid] = spring
 
       // Compute the force after each step
       world.addEventListener('postStep', springs[uuid])
+      break
+    }
+    case 'setSpringStiffness': {
+      springInstances[uuid].stiffness = props
+      break
+    }
+    case 'setSpringRestLength': {
+      springInstances[uuid].restLength = props
+      break
+    }
+    case 'setSpringDamping': {
+      springInstances[uuid].damping = props
       break
     }
     case 'removeSpring': {


### PR DESCRIPTION
# What?

This PR adds the following setter methods to `Spring`:
      - `stiffness`
      - `restLength`
      - `damping`

# Why?

Since there's no support for prismatic constraint, with the right spring settings, we could simulate a linear actuator, or a muscle contraction using spring.

# How?

- Adds 3 new methods to the hook and worker.
- Updates the demo to dynamically change the spring length on pointer down:
 
https://user-images.githubusercontent.com/2729225/114787089-17bf1580-9d77-11eb-9aac-b95214203aa2.mp4

