### PR TITLE
Improve compatibility with `create-react-app` by replacing `??` from the source

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -178,7 +178,7 @@ function subscribe(
   return (callback: (value: any) => void) => {
     const id = subscriptionGuid++
     subscriptions[id] = callback
-    post(ref, worker, 'subscribe', index, { id, type, target: target ?? 'bodies' })
+    post(ref, worker, 'subscribe', index, { id, type, target: (target === undefined || target === null) ? 'bodies' : target})
     return () => {
       delete subscriptions[id]
       worker.postMessage({ op: 'unsubscribe', props: id })
@@ -353,7 +353,7 @@ export function useParticle(fn: ParticleFn, fwdRef?: React.MutableRefObject<THRE
   return useBody('Particle', fn, () => [], fwdRef, deps)
 }
 export function useSphere(fn: SphereFn, fwdRef?: React.MutableRefObject<THREE.Object3D>, deps?: any[]) {
-  return useBody('Sphere', fn, (radius) => [radius ?? 1], fwdRef, deps)
+  return useBody('Sphere', fn, (radius) => [(radius === undefined || radius === null) ? 1 : radius], fwdRef, deps)
 }
 export function useTrimesh(fn: TrimeshFn, fwdRef?: React.MutableRefObject<THREE.Object3D>, deps?: any[]) {
   return useBody(

--- a/src/worker.js
+++ b/src/worker.js
@@ -92,7 +92,7 @@ self.onmessage = (e) => {
       state.world.solver.tolerance = tolerance
       state.world.solver.iterations = iterations
       state.world.broadphase = new (broadphases[broadphase + 'Broadphase'] || NaiveBroadphase)(state.world)
-      state.world.broadphase.axisIndex = axisIndex ?? 0
+      state.world.broadphase.axisIndex = (axisIndex === undefined || axisIndex === null ) ? 0 : axisIndex
       Object.assign(state.world.defaultContactMaterial, defaultContactMaterial)
       state.config.step = step
       break


### PR DESCRIPTION
Removes nullish coalescing operator `??` from code to improve build compatibility.

Given the current use cases seems like `||` could also be an acceptable replacement, but I went with the more accurate replacement to make sure that I'm not changing the behavior.

This PR fixes #198 