### PR TITLE
Add 'shouldInvalidate' To Allow Pausing

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -16,6 +16,7 @@ import type { AtomicProps } from './hooks'
 
 export type ProviderProps = {
   children: React.ReactNode
+  shouldInvalidate?: boolean
   gravity?: number[]
   tolerance?: number
   step?: number
@@ -133,6 +134,7 @@ function apply(index: number, buffers: Buffers, object?: Object3D) {
 
 export default function Provider({
   children,
+  shouldInvalidate = true,
   step = 1 / 60,
   gravity = [0, -10, 0],
   tolerance = 0.001,
@@ -211,7 +213,9 @@ export default function Provider({
                 apply(bodies.current[ref.uuid], buffers, ref)
               }
             }
-            invalidate()
+            if (shouldInvalidate) {
+              invalidate()
+            }
           }
 
           break


### PR DESCRIPTION
Addressing #212, this lets the developer control when the simulation steps. By default, this doesn't change the behavior of `<Physics/>`, but with `shouldInvalidate` set to false a new step is triggered when props change or when `invalidate()` is called somewhere in the tree.