### PR TITLE
Expose WakeUp & Sleep API

### DIFF
--- a/examples/src/demos/SphereDebug.js
+++ b/examples/src/demos/SphereDebug.js
@@ -1,16 +1,28 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { Debug, Physics, useSphere, usePlane } from '@react-three/cannon'
 
 function ScalableBall() {
-  const [ref] = useSphere(() => ({
+  const [ref, api] = useSphere(() => ({
     mass: 1,
     args: 1,
     position: [0, 5, 0],
   }))
+  const [sleeping, setSleeping] = useState(false)
+
+  // Very quick demo to test forced sleep states. Catch ball mid-air to stop it.
+  const toggle = () => {
+    if (sleeping) {
+      setSleeping(false)
+      api.wakeUp()
+    } else {
+      setSleeping(true)
+      api.sleep()
+    }
+  }
 
   return (
-    <mesh castShadow receiveShadow ref={ref}>
+    <mesh castShadow receiveShadow ref={ref} onClick={toggle}>
       <sphereGeometry args={[1, 32, 32]} />
       <meshStandardMaterial color="blue" transparent opacity={0.5} />
     </mesh>
@@ -33,7 +45,7 @@ export default function App() {
       <color attach="background" args={['#a6d1f6']} />
       <hemisphereLight />
       <directionalLight position={[5, 10, 5]} castShadow />
-      <Physics>
+      <Physics allowSleep>
         <Debug scale={1.1}>
           <Plane />
           <ScalableBall />

--- a/examples/src/demos/Trimesh.js
+++ b/examples/src/demos/Trimesh.js
@@ -4,7 +4,7 @@ import { Physics, useSphere, useTrimesh } from '@react-three/cannon'
 import { OrbitControls, TorusKnot, useGLTF } from '@react-three/drei'
 import create from 'zustand'
 
-const [useStore] = create((set) => ({
+const useStore = create((set) => ({
   isPaused: false,
   pause: () => set({ isPaused: true }),
   play: () => set({ isPaused: false }),

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -104,6 +104,8 @@ export interface WorkerApi extends WorkerProps<AtomicProps> {
   applyImpulse: (impulse: Triplet, worldPoint: Triplet) => void
   applyLocalForce: (force: Triplet, localPoint: Triplet) => void
   applyLocalImpulse: (impulse: Triplet, localPoint: Triplet) => void
+  wakeUp: () => void
+  sleep: () => void
 }
 
 interface PublicApi extends WorkerApi {
@@ -341,6 +343,13 @@ function useBody<B extends BodyProps<unknown>>(
         },
         applyLocalImpulse(impulse: Triplet, localPoint: Triplet) {
           post(ref, worker, 'applyLocalImpulse', index, [impulse, localPoint])
+        },
+        // force particular sleep state
+        wakeUp() {
+          post(ref, worker, 'wakeUp', index)
+        },
+        sleep() {
+          post(ref, worker, 'sleep', index)
         },
       }
     }

--- a/src/worker.js
+++ b/src/worker.js
@@ -491,5 +491,14 @@ self.onmessage = (e) => {
       state.vehicles[uuid].setBrake(brake, wheelIndex)
       break
     }
+
+    case 'wakeUp': {
+      state.bodies[uuid].wakeUp()
+      break
+    }
+    case 'sleep': {
+      state.bodies[uuid].sleep()
+      break
+    }
   }
 }


### PR DESCRIPTION
Low hanging fruit I've seen requested. Addresses #137, allowing one to forcefully set a body's wake state. SphereDebug example amended with a quick demo.

As an aside, I'd prefer "wake" to wakeUp, but hey. `wakeUp()` retained for legacy familiarity.