### PR TITLE
feat: add applyTorque API to body

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,6 +261,7 @@ interface WorkerApi extends WorkerProps<AtomicProps> {
   applyImpulse: (impulse: Triplet, worldPoint: Triplet) => void
   applyLocalForce: (force: Triplet, localPoint: Triplet) => void
   applyLocalImpulse: (impulse: Triplet, localPoint: Triplet) => void
+  applyTorque: (torque: Triplet) => void
 }
 
 interface PublicApi extends WorkerApi {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -104,6 +104,7 @@ export interface WorkerApi extends WorkerProps<AtomicProps> {
   applyImpulse: (impulse: Triplet, worldPoint: Triplet) => void
   applyLocalForce: (force: Triplet, localPoint: Triplet) => void
   applyLocalImpulse: (impulse: Triplet, localPoint: Triplet) => void
+  applyTorque: (torque: Triplet) => void
   wakeUp: () => void
   sleep: () => void
 }
@@ -343,6 +344,9 @@ function useBody<B extends BodyProps<unknown>>(
         },
         applyLocalImpulse(impulse: Triplet, localPoint: Triplet) {
           post(ref, worker, 'applyLocalImpulse', index, [impulse, localPoint])
+        },
+        applyTorque(torque: Triplet) {
+          post(ref, worker, 'applyTorque', index, [torque])
         },
         // force particular sleep state
         wakeUp() {

--- a/src/worker.js
+++ b/src/worker.js
@@ -273,6 +273,9 @@ self.onmessage = (e) => {
     case 'applyLocalImpulse':
       state.bodies[uuid].applyLocalImpulse(new Vec3(...props[0]), new Vec3(...props[1]))
       break
+    case 'applyTorque':
+      state.bodies[uuid].applyTorque(new Vec3(...props[0]))
+      break
     case 'addConstraint': {
       const [bodyA, bodyB, optns] = props
       let { pivotA, pivotB, axisA, axisB, ...options } = optns


### PR DESCRIPTION
Exposes Cannon's [`applyTorque`](https://pmndrs.github.io/cannon-es/docs/classes/body.html#applytorque) through the public hook API.