### PR TITLE
Add types for all worker messages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -254,25 +254,37 @@ function useRaycastAll(options: RayOptns, callback: (e: Event) => void, deps: an
 ### Returned api
 
 ```typescript
-interface WorkerApi extends WorkerProps<AtomicProps> {
-  position: WorkerVec
-  rotation: WorkerVec
-  velocity: WorkerVec
-  angularVelocity: WorkerVec
-  linearFactor: WorkerVec
-  angularFactor: WorkerVec
-  applyForce: (force: Triplet, worldPoint: Triplet) => void
-  applyImpulse: (impulse: Triplet, worldPoint: Triplet) => void
-  applyLocalForce: (force: Triplet, localPoint: Triplet) => void
-  applyLocalImpulse: (impulse: Triplet, localPoint: Triplet) => void
-  applyTorque: (torque: Triplet) => void
-}
+type WorkerApi = AtomicApi &
+  VectorApi & {
+    applyForce: (force: Triplet, worldPoint: Triplet) => void
+    applyImpulse: (impulse: Triplet, worldPoint: Triplet) => void
+    applyLocalForce: (force: Triplet, localPoint: Triplet) => void
+    applyLocalImpulse: (impulse: Triplet, localPoint: Triplet) => void
+    applyTorque: (torque: Triplet) => void
+    wakeUp: () => void
+    sleep: () => void
+  }
 
 interface PublicApi extends WorkerApi {
   at: (index: number) => WorkerApi
 }
 
 type Api = [React.MutableRefObject<THREE.Object3D | null>, PublicApi]
+
+type AtomicApi = {
+  [K in keyof AtomicProps]: {
+    set: (value: AtomicProps[K]) => void
+    subscribe: (callback: (value: AtomicProps[K]) => void) => () => void
+  }
+}
+
+type VectorApi = {
+  [K in keyof VectorProps]: {
+    set: (x: number, y: number, z: number) => void
+    copy: ({ x, y, z }: Vector3 | Euler) => void
+    subscribe: (callback: (value: Triplet) => void) => () => void
+  }
+}
 
 type ConstraintApi = [
   React.MutableRefObject<THREE.Object3D | null>,
@@ -340,37 +352,34 @@ type ProviderProps = {
   size?: number
 }
 
-interface AtomicProps {
-  mass?: number
-  material?: MaterialOptions
-  linearDamping?: number
-  angularDamping?: number
-  allowSleep?: boolean
-  sleepSpeedLimit?: number
-  sleepTimeLimit?: number
-  collisionFilterGroup?: number
-  collisionFilterMask?: number
-  collisionResponse?: number
-  fixedRotation?: boolean
-  userData?: object
-  isTrigger?: boolean
+type AtomicProps = {
+  allowSleep: boolean
+  angularDamping: number
+  collisionFilterGroup: number
+  collisionFilterMask: number
+  collisionResponse: number
+  fixedRotation: boolean
+  isTrigger: boolean
+  linearDamping: number
+  mass: number
+  material: MaterialOptions
+  sleepSpeedLimit: number
+  sleepTimeLimit: number
+  userData: {}
 }
 
 type Triplet = [x: number, y: number, z: number]
 
-interface BodyProps<T = unknown> extends AtomicProps {
-  args?: T
-  position?: Triplet
-  rotation?: Triplet
-  velocity?: Triplet
-  angularVelocity?: Triplet
-  linearFactor?: Triplet
-  angularFactor?: Triplet
-  type?: 'Dynamic' | 'Static' | 'Kinematic'
-  onCollide?: (e: CollideEvent) => void
-  onCollideBegin?: (e: CollideBeginEvent) => void
-  onCollideEnd?: (e: CollideEndEvent) => void
-}
+type VectorProps = Record<VectorName, Triplet>
+
+type BodyProps<T = unknown> = Partial<AtomicProps> &
+  Partial<VectorProps> & {
+    args?: T
+    type?: 'Dynamic' | 'Static' | 'Kinematic'
+    onCollide?: (e: CollideEvent) => void
+    onCollideBegin?: (e: CollideBeginEvent) => void
+    onCollideEnd?: (e: CollideEndEvent) => void
+  }
 
 type Event = RayhitEvent | CollideEvent | CollideBeginEvent | CollideEndEvent
 type CollideEvent = {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,7 +1,16 @@
+import type { RayOptions } from 'cannon-es'
 import type { Object3D } from 'three'
 import type { WorkerCollideEvent, WorkerRayhitEvent } from './Provider'
-import type { AtomicProps, BodyProps, BodyShapeType } from './hooks'
-import type React from 'react'
+import type {
+  AtomicProps,
+  BodyProps,
+  BodyShapeType,
+  ConstraintTypes,
+  SpringOptns,
+  Triplet,
+  WheelInfoOptions,
+} from './hooks'
+import type { MutableRefObject } from 'react'
 import { createContext } from 'react'
 
 export type Buffers = { positions: Float32Array; quaternions: Float32Array }
@@ -31,12 +40,193 @@ export type RayhitEvent = Omit<WorkerRayhitEvent['data'], 'body'> & { body: Obje
 export type Event = RayhitEvent | CollideEvent | CollideBeginEvent | CollideEndEvent
 export type Events = { [uuid: string]: (e: Event) => void }
 export type Subscriptions = {
-  [id: string]: (value: AtomicProps[keyof AtomicProps] | number[]) => void
+  [id: string]: (value: AtomicProps[AtomicName] | Triplet) => void
+}
+
+export const atomicNames = [
+  'allowSleep',
+  'angularDamping',
+  'collisionFilterGroup',
+  'collisionFilterMask',
+  'collisionResponse',
+  'fixedRotation',
+  'isTrigger',
+  'linearDamping',
+  'mass',
+  'material',
+  'sleepSpeedLimit',
+  'sleepTimeLimit',
+  'userData',
+] as const
+export type AtomicName = typeof atomicNames[number]
+
+export const vectorNames = [
+  'angularFactor',
+  'angularVelocity',
+  'linearFactor',
+  'position',
+  'rotation',
+  'velocity',
+] as const
+export type VectorName = typeof vectorNames[number]
+export type CannonVectorName = Exclude<VectorName, 'rotation'> | 'quaternion'
+
+export type SetOpName<T extends AtomicName | CannonVectorName> = `set${Capitalize<T>}`
+export type SubscriptionName = AtomicName | CannonVectorName | 'sliding'
+
+type Operation<T extends string, P> = { op: T } & (P extends void ? {} : { props: P })
+type WithUUID<T extends string, P = void> = Operation<T, P> & { uuid: string }
+type WithUUIDs<T extends string, P = void> = Operation<T, P> & { uuid: string[] }
+
+type AddConstraintMessage = WithUUID<'addConstraint', [uuidA: string, uuidB: string, options: {}]> & {
+  type: 'Hinge' | ConstraintTypes
+}
+
+type DisableConstraintMessage = WithUUID<'disableConstraint'>
+type EnableConstraintMessage = WithUUID<'enableConstraint'>
+type RemoveConstraintMessage = WithUUID<'removeConstraint'>
+
+type ConstraintMessage =
+  | AddConstraintMessage
+  | DisableConstraintMessage
+  | EnableConstraintMessage
+  | RemoveConstraintMessage
+
+type DisableConstraintMotorMessage = WithUUID<'disableConstraintMotor'>
+type EnableConstraintMotorMessage = WithUUID<'enableConstraintMotor'>
+type SetConstraintMotorMaxForce = WithUUID<'setConstraintMotorMaxForce', number>
+type SetConstraintMotorSpeed = WithUUID<'setConstraintMotorSpeed', number>
+
+type ConstraintMotorMessage =
+  | DisableConstraintMotorMessage
+  | EnableConstraintMotorMessage
+  | SetConstraintMotorSpeed
+  | SetConstraintMotorMaxForce
+
+type AddSpringMessage = WithUUID<'addSpring', [uuidA: string, uuidB: string, options: SpringOptns]>
+type RemoveSpringMessage = WithUUID<'removeSpring'>
+
+type SetSpringDampingMessage = WithUUID<'setSpringDamping', number>
+type SetSpringRestLengthMessage = WithUUID<'setSpringRestLength', number>
+type SetSpringStiffnessMessage = WithUUID<'setSpringStiffness', number>
+
+type SpringMessage =
+  | AddSpringMessage
+  | RemoveSpringMessage
+  | SetSpringDampingMessage
+  | SetSpringRestLengthMessage
+  | SetSpringStiffnessMessage
+
+export type RayMode = 'Closest' | 'Any' | 'All'
+
+export type AddRayMessage = WithUUID<
+  'addRay',
+  {
+    from?: Triplet
+    mode: RayMode
+    to?: Triplet
+  } & Pick<
+    RayOptions,
+    'checkCollisionResponse' | 'collisionFilterGroup' | 'collisionFilterMask' | 'skipBackfaces'
+  >
+>
+type RemoveRayMessage = WithUUID<'removeRay'>
+
+type RayMessage = AddRayMessage | RemoveRayMessage
+
+type AddRaycastVehicleMessage = WithUUIDs<
+  'addRaycastVehicle',
+  [
+    chassisBodyUUID: string | undefined,
+    wheelsUUID: (string | undefined)[],
+    wheelInfos: WheelInfoOptions[],
+    indexForwardAxis: number,
+    indexRightAxis: number,
+    indexUpAxis: number,
+  ]
+>
+type RemoveRaycastVehicleMessage = WithUUIDs<'removeRaycastVehicle'>
+
+type ApplyRaycastVehicleEngineForceMessage = WithUUID<
+  'applyRaycastVehicleEngineForce',
+  [value: number, wheelIndex: number]
+>
+type SetRaycastVehicleBrakeMessage = WithUUID<'setRaycastVehicleBrake', [brake: number, wheelIndex: number]>
+type SetRaycastVehicleSteeringValueMessage = WithUUID<
+  'setRaycastVehicleSteeringValue',
+  [value: number, wheelIndex: number]
+>
+
+type RaycastVehicleMessage =
+  | AddRaycastVehicleMessage
+  | ApplyRaycastVehicleEngineForceMessage
+  | RemoveRaycastVehicleMessage
+  | SetRaycastVehicleBrakeMessage
+  | SetRaycastVehicleSteeringValueMessage
+
+type AtomicMessage = WithUUID<SetOpName<AtomicName>, any>
+type VectorMessage = WithUUID<SetOpName<CannonVectorName>, Triplet>
+
+type ApplyForceMessage = WithUUID<'applyForce', [force: Triplet, worldPoint: Triplet]>
+type ApplyImpulseMessage = WithUUID<'applyImpulse', [impulse: Triplet, worldPoint: Triplet]>
+type ApplyLocalForceMessage = WithUUID<'applyLocalForce', [force: Triplet, localPoint: Triplet]>
+type ApplyLocalImpulseMessage = WithUUID<'applyLocalImpulse', [impulse: Triplet, localPoint: Triplet]>
+type ApplyTorque = WithUUID<'applyTorque', [torque: Triplet]>
+
+type ApplyMessage =
+  | ApplyForceMessage
+  | ApplyImpulseMessage
+  | ApplyLocalForceMessage
+  | ApplyLocalImpulseMessage
+  | ApplyTorque
+
+type SerializableBodyProps = {
+  onCollide: boolean
+}
+
+type AddBodiesMessage = WithUUIDs<'addBodies', SerializableBodyProps[]> & { type: BodyShapeType }
+type RemoveBodiesMessage = WithUUIDs<'removeBodies'>
+
+type BodiesMessage = AddBodiesMessage | RemoveBodiesMessage
+
+type SleepMessage = WithUUID<'sleep'>
+type WakeUpMessage = WithUUID<'wakeUp'>
+
+export type SubscriptionTarget = 'bodies' | 'vehicles'
+
+type SubscribeMessage = WithUUID<
+  'subscribe',
+  {
+    id: number
+    target: SubscriptionTarget
+    type: SubscriptionName
+  }
+>
+type UnsubscribeMessage = Operation<'unsubscribe', number>
+
+type SubscriptionMessage = SubscribeMessage | UnsubscribeMessage
+
+type CannonMessage =
+  | ApplyMessage
+  | AtomicMessage
+  | BodiesMessage
+  | ConstraintMessage
+  | ConstraintMotorMessage
+  | RaycastVehicleMessage
+  | RayMessage
+  | SleepMessage
+  | SpringMessage
+  | SubscriptionMessage
+  | VectorMessage
+  | WakeUpMessage
+
+export interface CannonWorker extends Worker {
+  postMessage: (message: CannonMessage) => void
 }
 
 export type ProviderContext = {
-  worker: Worker
-  bodies: React.MutableRefObject<{ [uuid: string]: number }>
+  worker: CannonWorker
+  bodies: MutableRefObject<{ [uuid: string]: number }>
   buffers: Buffers
   refs: Refs
   events: Events


### PR DESCRIPTION
With this we will have types for all messages being sent to the worker.

Maybe someone who's better at TypeScript can figure out a way to write a replacement post function, but I couldn't figure it out.

Once again, I want to suggest merging #242 because the ground truth of the system is that `ref.current` is often null and we avoid posting messages to the worker when that happens. We should not just close our eyes and pretend like it always has a value.
