### PR TITLE
Fix return type of subscribe function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ useFrame(({ clock }) => api.position.set(Math.sin(clock.getElapsedTime()) * 5, 0
 const velocity = useRef([0, 0, 0])
 useEffect(() => {
   const unsubscribe = api.velocity.subscribe((v) => (velocity.current = v))
-  return () => unsubscribe()
+  return unsubscribe
 }, [])
 ```
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -84,7 +84,7 @@ export interface CompoundBodyProps extends BodyProps {
 interface WorkerVec {
   set: (x: number, y: number, z: number) => void
   copy: ({ x, y, z }: Vector3 | Euler) => void
-  subscribe: (callback: (value: Triplet) => void) => void
+  subscribe: (callback: (value: Triplet) => void) => () => void
 }
 
 export type WorkerProps<T> = {


### PR DESCRIPTION
The example in Readme calls for using unsubscribe in useEffect like this: 
`return ()=>unsubscribe()`
This raises an error as the return type of `api.whatever.subscribe(...)` is void.
In fact proper value is returned, but the example wraps unnecessarily and type definition is `void` instead of `()=>void`.
Also fixed Readme because this arrow function is not needed.
Could be even 
```
useEffect(() => api.velocity.subscribe((v) => (velocity.current = v)), [])
```
instead of 
```
useEffect(() => {
  const unsubscribe = api.velocity.subscribe((v) => (velocity.current = v))
  return () => unsubscribe()
}, [])
```
but I don't have enough courage to change that much ;)