### PR TITLE
Convert Trimesh Example to typescript

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -436,7 +436,7 @@ type RayhitEvent = {
 }
 
 type CylinderArgs = [radiusTop?: number, radiusBottom?: number, height?: number, numSegments?: number]
-type TrimeshArgs = [vertices: number[], indices: number[]]
+type TrimeshArgs = [vertices: ArrayLike<number>, indices: ArrayLike<number>]
 type HeightfieldArgs = [
   data: number[][],
   options: { elementSize?: number; maxValue?: number; minValue?: number },

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -68,7 +68,7 @@ export type ShapeType =
 export type BodyShapeType = ShapeType | 'Compound'
 
 export type CylinderArgs = [radiusTop?: number, radiusBottom?: number, height?: number, numSegments?: number]
-export type TrimeshArgs = [vertices: number[], indices: number[]]
+export type TrimeshArgs = [vertices: ArrayLike<number>, indices: ArrayLike<number>]
 export type HeightfieldArgs = [
   data: number[][],
   options: { elementSize?: number; maxValue?: number; minValue?: number },


### PR DESCRIPTION
`BufferGeometry` uses `ArrayLike` which is not as strict as `Array` prompting a change to `TrimeshArgs` to support this use case without additional work.
