### PR TITLE
[Examples] Readme & Usability Improvements

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "r3f-cannon-demos",
+  "name": "@react-three/cannon-examples",
   "version": "1.0.0",
   "description": "",
   "keywords": [],

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,15 +1,21 @@
-This projects relies an on an alias pointing into `../dist/index`, the parent project has to be built previously.
+# @react-three/cannon-examples
+
+The examples rely on an alias pointing to `../dist/index`, the parent project must have been built previously.
+
+To build the parent project:
 
 ```bash
 cd ..
 yarn
-yarn build
+npm run build
 cd examples
 yarn
 ```
 
-from then on:
+To start the dev server:
 
 ```bash
-yarn start
+npm run dev
 ```
+
+And visit http://localhost:3000 in your browser

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -48,7 +48,7 @@ function Intro() {
         </Switch>
       </Suspense>
       <Demos />
-      <a href="https://github.com/react-spring/use-cannon" style={{ color: bright ? '#2c2d31' : 'white' }}>
+      <a href="https://github.com/pmndrs/use-cannon" style={{ color: bright ? '#2c2d31' : 'white' }}>
         Github
       </a>
     </Page>

--- a/examples/src/styles.ts
+++ b/examples/src/styles.ts
@@ -60,7 +60,7 @@ const Global = createGlobalStyle`
     overscroll-behavior-y: none;
     font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif;
     color: black;
-    background: white;
+    background: #171720;
   }
 `
 


### PR DESCRIPTION
- The default background color is now dark so that the buttons & github link are legible before the scene loads
- Change the github link from `react-spring/use-cannon` to `pmndrs/use-cannon`
- Update the readme to use new run syntax & provide URL to visit when developing
- Improve grammar in readme
- Change package name from `r3f-cannon-demos` to `@react-three/cannon-examples`
