### PR TITLE
use forwardRef without casting

### DIFF
--- a/examples/src/demos/Constraints.tsx
+++ b/examples/src/demos/Constraints.tsx
@@ -2,7 +2,6 @@ import { forwardRef, useEffect, useRef, useState } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { Physics, useSphere, useBox, useSpring } from '@react-three/cannon'
 
-import type { RefObject } from 'react'
 import type { BoxProps, SphereProps, Triplet } from '@react-three/cannon'
 import type { Object3D } from 'three'
 
@@ -15,7 +14,7 @@ const Box = forwardRef<Object3D, BoxProps>((props, ref) => {
       linearDamping: 0.7,
       ...props,
     }),
-    ref as RefObject<Object3D>,
+    ref,
   )
   return (
     <mesh ref={ref}>
@@ -26,10 +25,7 @@ const Box = forwardRef<Object3D, BoxProps>((props, ref) => {
 })
 
 const Ball = forwardRef<Object3D, SphereProps>((props, ref) => {
-  const [, { position }] = useSphere(
-    () => ({ type: 'Kinematic', args: 0.5, ...props }),
-    ref as RefObject<Object3D>,
-  )
+  const [, { position }] = useSphere(() => ({ type: 'Kinematic', args: 0.5, ...props }), ref)
   useFrame(({ mouse: { x, y }, viewport: { height, width } }) =>
     position.set((x * width) / 2, (y * height) / 2, 0),
   )

--- a/examples/src/demos/HingeMotor.tsx
+++ b/examples/src/demos/HingeMotor.tsx
@@ -85,7 +85,7 @@ const ConstraintPart = forwardRef<Object3D | null, ConstraintPartProps>(
         mass: 1,
         ...props,
       }),
-      ref as RefObject<Object3D>,
+      ref,
     )
 
     const [, , hingeApi] = useHingeConstraint(bodyRef, parent[0], {
@@ -135,7 +135,7 @@ const Robot = forwardRef<Object3D>((_, legsLeftRef) => {
 
   const legsRightRef = useRef<Object3D>(null)
 
-  useLockConstraint(legsRightRef, legsLeftRef as RefObject<Object3D>, {})
+  useLockConstraint(legsRightRef, legsLeftRef, {})
 
   return (
     <group onPointerDown={() => setMotorSpeed(2)} onPointerUp={() => setMotorSpeed(7)}>

--- a/examples/src/demos/RaycastVehicle/Wheel.tsx
+++ b/examples/src/demos/RaycastVehicle/Wheel.tsx
@@ -2,7 +2,6 @@ import { forwardRef } from 'react'
 import { useGLTF } from '@react-three/drei'
 import { useCylinder } from '@react-three/cannon'
 
-import type { RefObject } from 'react'
 import type { BufferGeometry, Material, Object3D } from 'three'
 import type { GLTF } from 'three-stdlib/loaders/GLTFLoader'
 import type { CylinderProps } from '@react-three/cannon'
@@ -32,7 +31,7 @@ export const Wheel = forwardRef<Object3D, WheelProps>(({ radius = 0.7, leftSide,
       args: [radius, radius, 0.5, 16],
       ...props,
     }),
-    ref as RefObject<Object3D>,
+    ref,
   )
   return (
     <mesh ref={ref}>

--- a/readme.md
+++ b/readme.md
@@ -144,104 +144,80 @@ function Physics({
 
 function Debug({ children, color = 'black', scale = 1 }: DebugProps): JSX.Element
 
-function usePlane(
-  fn: GetByIndex<PlaneProps>,
-  fwdRef?: React.MutableRefObject<THREE.Object3D | null>,
-  deps?: any[],
-): Api
+function usePlane(fn: GetByIndex<PlaneProps>, fwdRef?: React.Ref<THREE.Object3D>, deps?: any[]): Api
 
-function useBox(
-  fn: GetByIndex<BoxProps>,
-  fwdRef?: React.MutableRefObject<THREE.Object3D | null>,
-  deps?: any[],
-): Api
+function useBox(fn: GetByIndex<BoxProps>, fwdRef?: React.Ref<THREE.Object3D>, deps?: any[]): Api
 
-function useCylinder(
-  fn: GetByIndex<CylinderProps>,
-  fwdRef?: React.MutableRefObject<THREE.Object3D | null>,
-  deps?: any[],
-): Api
+function useCylinder(fn: GetByIndex<CylinderProps>, fwdRef?: React.Ref<THREE.Object3D>, deps?: any[]): Api
 
 function useHeightfield(
   fn: GetByIndex<HeightfieldProps>,
-  fwdRef?: React.MutableRefObject<THREE.Object3D | null>,
+  fwdRef?: React.Ref<THREE.Object3D>,
   deps?: any[],
 ): Api
 
-function useParticle(
-  fn: GetByIndex<ParticleProps>,
-  fwdRef?: React.MutableRefObject<THREE.Object3D | null>,
-  deps?: any[],
-): Api
+function useParticle(fn: GetByIndex<ParticleProps>, fwdRef?: React.Ref<THREE.Object3D>, deps?: any[]): Api
 
-function useSphere(
-  fn: GetByIndex<SphereProps>,
-  fwdRef?: React.MutableRefObject<THREE.Object3D | null>,
-  deps?: any[],
-): Api
+function useSphere(fn: GetByIndex<SphereProps>, fwdRef?: React.Ref<THREE.Object3D>, deps?: any[]): Api
 
-function useTrimesh(
-  fn: GetByIndex<TrimeshProps>,
-  fwdRef?: React.MutableRefObject<THREE.Object3D | null>,
-  deps?: any[],
-): Api
+function useTrimesh(fn: GetByIndex<TrimeshProps>, fwdRef?: React.Ref<THREE.Object3D>, deps?: any[]): Api
 
 function useConvexPolyhedron(
   fn: GetByIndex<ConvexPolyhedronProps>,
-  fwdRef?: React.MutableRefObject<THREE.Object3D | null>,
+  fwdRef?: React.Ref<THREE.Object3D>,
   deps?: any[],
 ): Api
 
 function useCompoundBody(
   fn: GetByIndex<CompoundBodyProps>,
-  fwdRef?: React.MutableRefObject<THREE.Object3D | null>,
+  fwdRef?: React.Ref<THREE.Object3D>,
   deps?: any[],
 ): Api
 
 function useRaycastVehicle(
   fn: () => RaycastVehicleProps,
-  fwdRef?: React.MutableRefObject<THREE.Object3D | null>,
+  fwdRef?: React.Ref<THREE.Object3D>,
   deps: any[] = [],
-): [React.MutableRefObject<THREE.Object3D | null>, RaycastVehiclePublicApi]
+): [React.RefObject<THREE.Object3D>, RaycastVehiclePublicApi]
 
 function usePointToPointConstraint(
-  bodyA: React.MutableRefObject<THREE.Object3D | null>,
-  bodyB: React.MutableRefObject<THREE.Object3D | null>,
+  bodyA: React.Ref<THREE.Object3D>,
+  bodyB: React.Ref<THREE.Object3D>,
   optns: PointToPointConstraintOpts,
   deps: any[] = [],
 ): ConstraintApi
 
 function useConeTwistConstraint(
-  bodyA: React.MutableRefObject<THREE.Object3D | null>,
-  bodyB: React.MutableRefObject<THREE.Object3D | null>,
+  bodyA: React.Ref<THREE.Object3D>,
+  bodyB: React.Ref<THREE.Object3D>,
   optns: ConeTwistConstraintOpts,
   deps: any[] = [],
 ): ConstraintApi
 
 function useDistanceConstraint(
-  bodyA: React.MutableRefObject<THREE.Object3D | null>,
-  bodyB: React.MutableRefObject<THREE.Object3D | null>,
+  bodyA: React.Ref<THREE.Object3D>,
+  bodyB: React.Ref<THREE.Object3D>,
   optns: DistanceConstraintOpts,
   deps: any[] = [],
 ): ConstraintApi
 
 function useHingeConstraint(
-  bodyA: React.MutableRefObject<THREE.Object3D | null>,
-  bodyB: React.MutableRefObject<THREE.Object3D | null>,
+  bodyA: React.Ref<THREE.Object3D>,
+  bodyB: React.Ref<THREE.Object3D>,
   optns: HingeConstraintOpts,
   deps: any[] = [],
 ): ConstraintApi
 
 function useLockConstraint(
-  bodyA: React.MutableRefObject<THREE.Object3D | null>,
-  bodyB: React.MutableRefObject<THREE.Object3D | null>,
+  bodyA: React.Ref<THREE.Object3D>,
+  bodyB: React.Ref<THREE.Object3D>,
   optns: LockConstraintOpts,
   deps: any[] = [],
 ): ConstraintApi
 
 function useSpring(
-  bodyA: React.MutableRefObject<THREE.Object3D | null>,
-  bodyB: React.MutableRefObject<THREE.Object3D | null>,
+  bodyA: React.Ref<THREE.Object3D>,
+  bodyB: React.Ref<THREE.Object3D>,
   optns: SpringOptns,
   deps: any[] = [],
 ): void
@@ -269,7 +245,7 @@ interface PublicApi extends WorkerApi {
   at: (index: number) => WorkerApi
 }
 
-type Api = [React.MutableRefObject<THREE.Object3D | null>, PublicApi]
+type Api = [React.RefObject<THREE.Object3D>, PublicApi]
 
 type AtomicApi = {
   [K in keyof AtomicProps]: {
@@ -287,8 +263,8 @@ type VectorApi = {
 }
 
 type ConstraintApi = [
-  React.MutableRefObject<THREE.Object3D | null>,
-  React.MutableRefObject<THREE.Object3D | null>,
+  React.RefObject<THREE.Object3D>,
+  React.RefObject<THREE.Object3D>,
   {
     enable: () => void
     disable: () => void
@@ -296,8 +272,8 @@ type ConstraintApi = [
 ]
 
 type HingeConstraintApi = [
-  React.MutableRefObject<THREE.Object3D | null>,
-  React.MutableRefObject<THREE.Object3D | null>,
+  React.RefObject<THREE.Object3D>,
+  React.RefObject<THREE.Object3D>,
   {
     enable: () => void
     disable: () => void
@@ -309,8 +285,8 @@ type HingeConstraintApi = [
 ]
 
 type SpringApi = [
-  React.MutableRefObject<THREE.Object3D | null>,
-  React.MutableRefObject<THREE.Object3D | null>,
+  React.RefObject<THREE.Object3D>,
+  React.RefObject<THREE.Object3D>,
   {
     setStiffness: (value: number) => void
     setRestLength: (value: number) => void
@@ -522,8 +498,8 @@ interface WheelInfoOptions {
 }
 
 interface RaycastVehicleProps {
-  chassisBody: React.MutableRefObject<THREE.Object3D | null>
-  wheels: React.MutableRefObject<THREE.Object3D | null>[]
+  chassisBody: React.Ref<THREE.Object3D>
+  wheels: React.Ref<THREE.Object3D>[]
   wheelInfos: WheelInfoOptions[]
   indexForwardAxis?: number
   indexRightAxis?: number

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -137,8 +137,8 @@ type RayMessage = AddRayMessage | RemoveRayMessage
 type AddRaycastVehicleMessage = WithUUIDs<
   'addRaycastVehicle',
   [
-    chassisBodyUUID: string | undefined,
-    wheelsUUID: (string | undefined)[],
+    chassisBodyUUID: string,
+    wheelsUUID: string[],
     wheelInfos: WheelInfoOptions[],
     indexForwardAxis: number,
     indexRightAxis: number,


### PR DESCRIPTION
This is a backwards compatible change that enables the use of `forwardRef` without casting.

Currently we have to use forwardRef like this:
```typescript
const Ball = forwardRef<Object3D, SphereProps>((props, ref) => {
  const [, { position }] = useSphere(
    () => ({ type: 'Kinematic', args: 0.5, ...props }),
    ref as RefObject<Object3D>,
  )
}
```

With this change we can use `ref` directly:

```typescript
const Ball = forwardRef<Object3D, SphereProps>((props, ref) => {
  const [, { position }] = useSphere(() => ({ type: 'Kinematic', args: 0.5, ...props }), ref)
}
```