### PR TITLE
[TypeScript] Improve set and subscribe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,14 +284,14 @@ interface PublicApi extends WorkerApi {
 type Api = [React.RefObject<THREE.Object3D>, PublicApi]
 
 type AtomicApi = {
-  [K in keyof AtomicProps]: {
+  [K in AtomicName]: {
     set: (value: AtomicProps[K]) => void
     subscribe: (callback: (value: AtomicProps[K]) => void) => () => void
   }
 }
 
 type VectorApi = {
-  [K in keyof VectorProps]: {
+  [K in PublicVectorName]: {
     set: (x: number, y: number, z: number) => void
     copy: ({ x, y, z }: Vector3 | Euler) => void
     subscribe: (callback: (value: Triplet) => void) => () => void
@@ -383,7 +383,7 @@ type AtomicProps = {
 type Broadphase = 'Naive' | 'SAP'
 type Triplet = [x: number, y: number, z: number]
 
-type VectorProps = Record<VectorName, Triplet>
+type VectorProps = Record<PublicVectorName, Triplet>
 
 type BodyProps<T = unknown> = Partial<AtomicProps> &
   Partial<VectorProps> & {

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -10,9 +10,10 @@ import { context } from './setup'
 // @ts-expect-error Types are not setup for this yet
 import CannonWorker from '../src/worker'
 import { useUpdateWorldPropsEffect } from './useUpdateWorldPropsEffect'
+import { subscriptionNames } from './setup'
 
-import type { Buffers, Refs, Subscriptions, ProviderContext } from './setup'
-import type { AtomicProps, Triplet } from './hooks'
+import type { AtomicName, Buffers, PropValue, Refs, ProviderContext } from './setup'
+import type { Triplet } from './hooks'
 
 function noop() {
   /**/
@@ -47,10 +48,12 @@ export type ProviderProps = {
   size?: number
 }
 
+type Observation = { [K in AtomicName]: [number, PropValue<K>, K] }[AtomicName]
+
 type WorkerFrameMessage = {
   data: Buffers & {
     op: 'frame'
-    observations: [key: string, value: AtomicProps[keyof AtomicProps] | number[]][]
+    observations: Observation[]
     active: boolean
     bodies?: string[]
   }
@@ -176,7 +179,12 @@ export default function Provider({
     quaternions: new Float32Array(size * 4),
   }))
   const [events] = useState<ProviderContext['events']>({})
-  const [subscriptions] = useState<Subscriptions>({})
+  const [subscriptions] = useState<ProviderContext['subscriptions']>(
+    subscriptionNames.reduce<ProviderContext['subscriptions']>((previousValue, currentValue) => {
+      previousValue[currentValue] = {}
+      return previousValue
+    }, {} as ProviderContext['subscriptions']),
+  )
 
   const bodies = useRef<{ [uuid: string]: number }>({})
   const loop = useCallback(() => {
@@ -222,8 +230,10 @@ export default function Provider({
             }
           }
 
-          e.data.observations.forEach(([key, value]) => {
-            if (subscriptions[key]) subscriptions[key](value)
+          e.data.observations.forEach(([id, value, type]) => {
+            callback = subscriptions[type][id] || noop
+            // HELP: We clearly know the type of the callback, but typescript can't deal with it
+            callback(value as never)
           })
 
           if (e.data.active) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -45,9 +45,10 @@ type CallbackByType<T extends { type: string }> = {
 
 type CannonEvents = { [uuid: string]: Partial<CallbackByType<CannonEvent>> }
 
-type Subscriptions = {
-  [K in SubscriptionName]: { [id: number]: (value: PropValue<K>) => void }
-}
+export type Subscription = Partial<{ [K in SubscriptionName]: (value: PropValue<K>) => void }>
+export type Subscriptions = Partial<{
+  [id: number]: Subscription
+}>
 
 export type PropValue<T extends SubscriptionName = SubscriptionName> = T extends AtomicName
   ? AtomicProps[T]

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -40,12 +40,22 @@ export type RayhitEvent = Omit<WorkerRayhitEvent['data'], 'body'> & { body: Obje
 
 type CannonEvent = CollideBeginEvent | CollideEndEvent | CollideEvent | RayhitEvent
 type CallbackByType<T extends { type: string }> = {
-  [uuid: string]: Partial<{ [K in T['type']]?: T extends { type: K } ? (e: T) => void : never }>
+  [K in T['type']]?: T extends { type: K } ? (e: T) => void : never
 }
 
-export type Subscriptions = {
-  [id: string]: (value: AtomicProps[AtomicName] | Triplet) => void
+type CannonEvents = { [uuid: string]: Partial<CallbackByType<CannonEvent>> }
+
+type Subscriptions = {
+  [K in SubscriptionName]: { [id: number]: (value: PropValue<K>) => void }
 }
+
+export type PropValue<T extends SubscriptionName = SubscriptionName> = T extends AtomicName
+  ? AtomicProps[T]
+  : T extends VectorName
+  ? Triplet
+  : T extends 'sliding'
+  ? boolean
+  : never
 
 export const atomicNames = [
   'allowSleep',
@@ -69,14 +79,17 @@ export const vectorNames = [
   'angularVelocity',
   'linearFactor',
   'position',
-  'rotation',
+  'quaternion',
   'velocity',
 ] as const
 export type VectorName = typeof vectorNames[number]
-export type CannonVectorName = Exclude<VectorName, 'rotation'> | 'quaternion'
 
-export type SetOpName<T extends AtomicName | CannonVectorName | WorldPropName> = `set${Capitalize<T>}`
-export type SubscriptionName = AtomicName | CannonVectorName | 'sliding'
+export const subscriptionNames = [...atomicNames, ...vectorNames, 'sliding'] as const
+export type SubscriptionName = typeof subscriptionNames[number]
+
+export type PublicVectorName = Exclude<VectorName, 'quaternion'> | 'rotation'
+
+export type SetOpName<T extends AtomicName | VectorName | WorldPropName> = `set${Capitalize<T>}`
 
 type Operation<T extends string, P> = { op: T } & (P extends void ? {} : { props: P })
 type WithUUID<T extends string, P = void> = Operation<T, P> & { uuid: string }
@@ -169,7 +182,7 @@ type RaycastVehicleMessage =
   | SetRaycastVehicleSteeringValueMessage
 
 type AtomicMessage = WithUUID<SetOpName<AtomicName>, any>
-type VectorMessage = WithUUID<SetOpName<CannonVectorName>, Triplet>
+type VectorMessage = WithUUID<SetOpName<VectorName>, Triplet>
 
 type ApplyForceMessage = WithUUID<'applyForce', [force: Triplet, worldPoint: Triplet]>
 type ApplyImpulseMessage = WithUUID<'applyImpulse', [impulse: Triplet, worldPoint: Triplet]>
@@ -238,7 +251,7 @@ export type ProviderContext = {
   bodies: MutableRefObject<{ [uuid: string]: number }>
   buffers: Buffers
   refs: Refs
-  events: CallbackByType<CannonEvent>
+  events: CannonEvents
   subscriptions: Subscriptions
 }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -119,7 +119,7 @@ self.onmessage = (e) => {
           value.toEuler(state.tempVector)
           value = state.tempVector.toArray()
         }
-        observations.push([id, value])
+        observations.push([id, value, type])
       }
       const message = {
         op: 'frame',


### PR DESCRIPTION
There is a very small functional change here where we pass the type of the subscription back from the worker with the result.

This allows us to be certain of the type of the value that will be passed to the callback.

Would love some help with the final piece of the puzzle, getting TypeScript to accept actually calling the callback.
