### PR TITLE
Add quaternion API, convert from quaternion to rotation correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,15 +266,21 @@ function useRaycastAll(
 ### Returned api
 
 ```typescript
-type WorkerApi = AtomicApi &
-  VectorApi & {
+type WorkerApi = {
+  [K in AtomicName]: AtomicApi<K>
+} &
+  {
+    [K in VectorName]: VectorApi
+  } & {
     applyForce: (force: Triplet, worldPoint: Triplet) => void
     applyImpulse: (impulse: Triplet, worldPoint: Triplet) => void
     applyLocalForce: (force: Triplet, localPoint: Triplet) => void
     applyLocalImpulse: (impulse: Triplet, localPoint: Triplet) => void
     applyTorque: (torque: Triplet) => void
-    wakeUp: () => void
+    quaternion: QuaternionApi
+    rotation: VectorApi
     sleep: () => void
+    wakeUp: () => void
   }
 
 interface PublicApi extends WorkerApi {
@@ -283,19 +289,21 @@ interface PublicApi extends WorkerApi {
 
 type Api = [React.RefObject<THREE.Object3D>, PublicApi]
 
-type AtomicApi = {
-  [K in AtomicName]: {
-    set: (value: AtomicProps[K]) => void
-    subscribe: (callback: (value: AtomicProps[K]) => void) => () => void
-  }
+type AtomicApi<K extends AtomicName> = {
+  set: (value: AtomicProps[K]) => void
+  subscribe: (callback: (value: AtomicProps[K]) => void) => () => void
+}
+
+type QuaternionApi = {
+  set: (x: number, y: number, z: number, w: number) => void
+  copy: ({ w, x, y, z }: Quaternion) => void
+  subscribe: (callback: (value: Quad) => void) => () => void
 }
 
 type VectorApi = {
-  [K in PublicVectorName]: {
-    set: (x: number, y: number, z: number) => void
-    copy: ({ x, y, z }: Vector3 | Euler) => void
-    subscribe: (callback: (value: Triplet) => void) => () => void
-  }
+  set: (x: number, y: number, z: number) => void
+  copy: ({ x, y, z }: Vector3 | Euler) => void
+  subscribe: (callback: (value: Triplet) => void) => () => void
 }
 
 type ConstraintApi = [
@@ -382,16 +390,19 @@ type AtomicProps = {
 
 type Broadphase = 'Naive' | 'SAP'
 type Triplet = [x: number, y: number, z: number]
+type Quad = [x: number, y: number, z: number, w: number]
 
-type VectorProps = Record<PublicVectorName, Triplet>
+type VectorProps = Record<VectorName, Triplet>
 
 type BodyProps<T = unknown> = Partial<AtomicProps> &
   Partial<VectorProps> & {
     args?: T
-    type?: 'Dynamic' | 'Static' | 'Kinematic'
     onCollide?: (e: CollideEvent) => void
     onCollideBegin?: (e: CollideBeginEvent) => void
     onCollideEnd?: (e: CollideEndEvent) => void
+    quaternion?: Quad
+    rotation?: Triplet
+    type?: 'Dynamic' | 'Static' | 'Kinematic'
   }
 
 type Event = RayhitEvent | CollideEvent | CollideBeginEvent | CollideEndEvent

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -6,6 +6,7 @@ import type {
   BodyProps,
   BodyShapeType,
   ConstraintTypes,
+  Quad,
   SpringOptns,
   Triplet,
   WheelInfoOptions,
@@ -54,6 +55,8 @@ export type PropValue<T extends SubscriptionName = SubscriptionName> = T extends
   ? AtomicProps[T]
   : T extends VectorName
   ? Triplet
+  : T extends 'quaternion'
+  ? Quad
   : T extends 'sliding'
   ? boolean
   : never
@@ -80,17 +83,15 @@ export const vectorNames = [
   'angularVelocity',
   'linearFactor',
   'position',
-  'quaternion',
   'velocity',
 ] as const
 export type VectorName = typeof vectorNames[number]
 
-export const subscriptionNames = [...atomicNames, ...vectorNames, 'sliding'] as const
+export const subscriptionNames = [...atomicNames, ...vectorNames, 'quaternion', 'sliding'] as const
 export type SubscriptionName = typeof subscriptionNames[number]
 
-export type PublicVectorName = Exclude<VectorName, 'quaternion'> | 'rotation'
-
-export type SetOpName<T extends AtomicName | VectorName | WorldPropName> = `set${Capitalize<T>}`
+export type SetOpName<T extends AtomicName | VectorName | WorldPropName | 'quaternion' | 'rotation'> =
+  `set${Capitalize<T>}`
 
 type Operation<T extends string, P> = { op: T } & (P extends void ? {} : { props: P })
 type WithUUID<T extends string, P = void> = Operation<T, P> & { uuid: string }
@@ -183,6 +184,8 @@ type RaycastVehicleMessage =
   | SetRaycastVehicleSteeringValueMessage
 
 type AtomicMessage = WithUUID<SetOpName<AtomicName>, any>
+type QuaternionMessage = WithUUID<SetOpName<'quaternion'>, Quad>
+type RotationMessage = WithUUID<SetOpName<'rotation'>, Triplet>
 type VectorMessage = WithUUID<SetOpName<VectorName>, Triplet>
 
 type ApplyForceMessage = WithUUID<'applyForce', [force: Triplet, worldPoint: Triplet]>
@@ -234,8 +237,10 @@ type CannonMessage =
   | BodiesMessage
   | ConstraintMessage
   | ConstraintMotorMessage
+  | QuaternionMessage
   | RaycastVehicleMessage
   | RayMessage
+  | RotationMessage
   | SleepMessage
   | SpringMessage
   | SubscriptionMessage

--- a/src/worker.js
+++ b/src/worker.js
@@ -28,7 +28,6 @@ const state = {
   world: new World(),
   config: { step: 1 / 60 },
   subscriptions: {},
-  tempVector: new Vec3(),
   bodiesNeedSyncing: false,
   lastCallTime: undefined,
 }
@@ -114,11 +113,7 @@ self.onmessage = (e) => {
         let object = state[target]
         if (!object || !object[uuid]) continue
         let value = object[uuid][type]
-        if (value instanceof Vec3) value = value.toArray()
-        else if (value instanceof Quaternion) {
-          value.toEuler(state.tempVector)
-          value = state.tempVector.toArray()
-        }
+        if (value instanceof Vec3 || value instanceof Quaternion) value = value.toArray()
         observations.push([id, value, type])
       }
       const message = {
@@ -193,6 +188,9 @@ self.onmessage = (e) => {
       state.bodies[uuid].position.set(props[0], props[1], props[2])
       break
     case 'setQuaternion':
+      state.bodies[uuid].quaternion.set(props[0], props[1], props[2], props[3])
+      break
+    case 'setRotation':
       state.bodies[uuid].quaternion.setFromEuler(props[0], props[1], props[2])
       break
     case 'setVelocity':


### PR DESCRIPTION
Fixes #286

- Added `QuaternionApi`
- Refactored `VectorApi` & `AtomicApi` to be more reusable
- `PublicVectorName` is no longer necessary
- Worker no longer needs a tempVector
- Updated README