### PR TITLE
fix: don't inline cannon-es

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import babel from '@rollup/plugin-babel'
 import resolve from '@rollup/plugin-node-resolve'
 import worker from 'rollup-plugin-web-worker-loader'
 
-const external = ['react', '@react-three/fiber', 'three']
+const external = ['react', '@react-three/fiber', 'three', 'cannon-es', 'cannon-es-debugger']
 const extensions = ['.js', '.jsx', '.ts', '.tsx', '.json']
 
 const getBabelOptions = ({ useESModules }, targets) => ({


### PR DESCRIPTION
Found out while trying to debug some things that `cannon-es` and `cannon-es-debugger` are inlined in the `use-cannon` bundle. Not sure if this is intentional or not?

They are listed as dependencies of this package so consumers will download the code twice on npm install. It also makes it harder to debug things locally, e.g. I tried to change some things in `node_modules/cannon-es` but didn't understand why the changes didn't go through

When building we get this warning
```(!) Missing global variable name
Use output.globals to specify browser global variable names corresponding to external modules
cannon-es (guessing 'cannonEs')
```

not sure if we should care about it or not