### PR TITLE
[Rollup] Set the runtime to automatic

### DIFF
--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -292,7 +292,7 @@
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@react-three/cannon@file:..":
-  version "4.0.1"
+  version "4.1.0"
   dependencies:
     cannon-es "^0.18.0"
     cannon-es-debugger "^0.1.4"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import babel from '@rollup/plugin-babel'
 import resolve from '@rollup/plugin-node-resolve'
 import worker from 'rollup-plugin-web-worker-loader'
 
-const external = ['react', '@react-three/fiber', 'three']
+const external = ['react', 'react/jsx-runtime', '@react-three/fiber', 'three']
 const extensions = ['.js', '.jsx', '.ts', '.tsx', '.json']
 
 const getBabelOptions = ({ useESModules }, targets) => ({
@@ -12,7 +12,7 @@ const getBabelOptions = ({ useESModules }, targets) => ({
   babelHelpers: 'runtime',
   presets: [
     ['@babel/preset-env', { loose: true, modules: false, targets }],
-    '@babel/preset-react',
+    ['@babel/preset-react', { runtime: 'automatic' }],
     '@babel/preset-typescript',
   ],
   plugins: [['@babel/transform-runtime', { regenerator: false, useESModules }]],


### PR DESCRIPTION
To enable the jsx runtime and get smaller/faster bundles

- mark the jsx-runtime as external