### PR TITLE
Add friction/Contact Material example

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,13 @@ function useRaycastAll(
   callback: (e: RayhitEvent) => void,
   deps: React.DependencyList = [],
 ): void
+
+function useContactMaterial(
+  materialA: MaterialOptions,
+  materialB: MaterialOptions,
+  options: ContactMaterialOptions,
+  deps: React.DependencyList = [],
+): void
 ```
 
 ### Returned api

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -62,7 +62,7 @@ function Demos() {
   return (
     <DemoPanel>
       {Object.entries(visibleComponents).map(([name], key) => (
-        <Link key={key} to={`/demo/${name}`}>
+        <Link key={key} to={`/demo/${name}`} title={name}>
           <Spot style={{ backgroundColor: name === routeName ? 'salmon' : 'white' }} />
         </Link>
       ))}

--- a/examples/src/demos/Friction.tsx
+++ b/examples/src/demos/Friction.tsx
@@ -1,0 +1,198 @@
+import React, { useState } from 'react'
+import { Canvas } from '@react-three/fiber'
+import type { BoxProps, PlaneProps, Triplet } from '@react-three/cannon'
+import { Physics, useContactMaterial, usePlane, useBox } from '@react-three/cannon'
+import { OrbitControls } from '@react-three/drei'
+
+const materialColors = {
+  ground: '#9b7653',
+  slippery: 'royalblue',
+  rubber: 'darkgrey',
+  bouncy: 'yellow',
+  box: '#BB8E51',
+} as const
+
+function Box({ color = 'white', ...props }: { color?: string } & BoxProps) {
+  const boxSize: Triplet = props.args || [1, 1, 1]
+  const [ref] = useBox(() => ({
+    args: boxSize,
+    mass: 10,
+    ...props,
+  }))
+  return (
+    <mesh ref={ref} castShadow receiveShadow>
+      <boxBufferGeometry args={boxSize} />
+      <meshLambertMaterial color={color} />
+    </mesh>
+  )
+}
+
+function Plane(props: PlaneProps) {
+  const [ref] = usePlane(() => ({ ...props }))
+  return (
+    <mesh ref={ref} receiveShadow>
+      <planeBufferGeometry args={[100, 100]} />
+      <meshStandardMaterial color={materialColors.ground} />
+    </mesh>
+  )
+}
+
+function PhysicsContent() {
+  const [rubberSlips, setRubberSlips] = useState(false)
+
+  const boxMaterial = 'box'
+  const groundMaterial = {
+    name: 'ground',
+  }
+  const slipperyMaterial = {
+    name: 'slippery',
+    /*
+    Friction for this material.
+    If non-negative, it will be used instead of the friction given by ContactMaterials.
+    If there's no matching ContactMaterial, the value from .defaultContactMaterial in the World will be used.
+    */
+    friction: 0,
+  }
+  const rubberMaterial = {
+    name: 'rubber',
+    /*
+    Setting the friction on both materials prevents overriding the friction given by ContactMaterials.
+    Since we want rubber to not be slippery we do not set this here and instead use a ContactMaterial.
+    See https://github.com/pmndrs/cannon-es/blob/e9f1bccd8caa250cc6e6cdaf85389058e1c9238e/src/world/World.ts#L661-L673
+    */
+    // friction: 0.9,
+  }
+  const bouncyMaterial = {
+    name: 'bouncy',
+    /*
+    Restitution for this material.
+    If non-negative, it will be used instead of the restitution given by ContactMaterials.
+    If there's no matching ContactMaterial, the value from .defaultContactMaterial in the World will be used.
+    */
+    restitution: 1.1,
+  }
+
+  useContactMaterial(groundMaterial, groundMaterial, {
+    friction: 0.4,
+    restitution: 0.3,
+    contactEquationStiffness: 1e8,
+    contactEquationRelaxation: 3,
+    frictionEquationStiffness: 1e8,
+  })
+  useContactMaterial(boxMaterial, groundMaterial, {
+    friction: 0.4,
+    restitution: 0.3,
+    contactEquationStiffness: 1e8,
+    contactEquationRelaxation: 3,
+    frictionEquationStiffness: 1e8,
+  })
+
+  useContactMaterial(boxMaterial, slipperyMaterial, {
+    friction: 0,
+    restitution: 0.3,
+  })
+  useContactMaterial(groundMaterial, slipperyMaterial, {
+    friction: 0,
+    restitution: 0.3,
+  })
+  useContactMaterial(slipperyMaterial, slipperyMaterial, {
+    friction: 0.1,
+    restitution: 0.3,
+  })
+
+  useContactMaterial(bouncyMaterial, slipperyMaterial, {
+    friction: 0,
+    restitution: 0.5,
+  })
+  useContactMaterial(bouncyMaterial, groundMaterial, {
+    restitution: 0.9,
+  })
+  useContactMaterial(bouncyMaterial, bouncyMaterial, {
+    restitution: 10.0, // This does nothing because bouncyMaterial already has a restitution
+  })
+
+  useContactMaterial(
+    rubberMaterial,
+    slipperyMaterial,
+    {
+      friction: rubberSlips ? 0 : 1,
+      restitution: 0.3,
+    },
+    [rubberSlips],
+  )
+  useContactMaterial(rubberMaterial, bouncyMaterial, {
+    restitution: 0.5,
+  })
+
+  return (
+    <group
+      onPointerUp={() => {
+        setRubberSlips((prev) => !prev)
+      }}
+    >
+      {/* Objects */}
+      <Box material={bouncyMaterial} position={[-7, 2, -2]} color={materialColors.bouncy} />
+      <Box material={boxMaterial} position={[-7, 2, 0]} color={materialColors.box} />
+      <Box material={rubberMaterial} position={[-7, 2, 2]} color={materialColors.rubber} />
+      <Box material={slipperyMaterial} position={[-7, 2, 4]} color={materialColors.slippery} />
+      {/* Floors */}
+      <Box
+        material={slipperyMaterial}
+        position={[-6, 1, 0]}
+        color={materialColors.slippery}
+        args={[4, 0.1, 10]}
+        type="Static"
+      />
+      <Box
+        material={bouncyMaterial}
+        position={[-2, 0.1, 0]}
+        color={materialColors.bouncy}
+        args={[4, 0.1, 10]}
+        type="Static"
+      />
+      <Box
+        material={rubberMaterial}
+        position={[15, 0.01, 0]}
+        color={materialColors.rubber}
+        args={[20, 0.1, 10]}
+        type="Static"
+      />
+      <Plane material={groundMaterial} rotation={[-Math.PI / 2, 0, 0]} />
+    </group>
+  )
+}
+
+export default () => (
+  <>
+    <Canvas shadows camera={{ position: [-5, 3, 8] }}>
+      <OrbitControls />
+      <pointLight position={[1, 2, 3]} castShadow />
+      <ambientLight intensity={0.2} />
+      <Physics gravity={[3, -9.81, 0]}>
+        <PhysicsContent />
+      </Physics>
+    </Canvas>
+    <div
+      style={{
+        position: 'absolute',
+        top: 20,
+        left: 50,
+        color: 'white',
+        fontSize: '1.2em',
+      }}
+    >
+      <pre>
+        * Gravity is aiming to the right
+        <br />
+        Click to toggle rubber slipping on slipper material
+        <br />
+        Materials:
+        {Object.keys(materialColors).map((name) => (
+          <div key={name}>
+            <span style={{ color: materialColors[name as keyof typeof materialColors] }}>- {name}</span>
+          </div>
+        ))}
+      </pre>
+    </div>
+  </>
+)

--- a/examples/src/demos/index.ts
+++ b/examples/src/demos/index.ts
@@ -15,6 +15,7 @@ const Triggers = { Component: lazy(() => import('./Triggers')) }
 const Trimesh = { Component: lazy(() => import('./Trimesh')) }
 const Heightfield = { Component: lazy(() => import('./Heightfield')) }
 const SphereDebug = { Component: lazy(() => import('./SphereDebug')) }
+const Friction = { Component: lazy(() => import('./Friction')) }
 
 export {
   MondayMorning,
@@ -32,4 +33,5 @@ export {
   Trimesh,
   Heightfield,
   SphereDebug,
+  Friction,
 }

--- a/src/Debug.tsx
+++ b/src/Debug.tsx
@@ -46,7 +46,7 @@ export function Debug({
   const api = useMemo(
     () => ({
       add(uuid: string, props: BodyProps, type: BodyShapeType) {
-        const body = propsToBody(uuid, props, type)
+        const body = propsToBody({ uuid, props, type })
         bodies.push(body)
         bodyMap[uuid] = body
       },

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,7 +2,7 @@ import { useLayoutEffect, useContext, useRef, useMemo, useEffect, useState } fro
 import { DynamicDrawUsage, Euler, InstancedMesh, MathUtils, Object3D, Quaternion, Vector3 } from 'three'
 import { context, debugContext } from './setup'
 
-import type { MaterialOptions } from 'cannon-es'
+import type { ContactMaterialOptions, MaterialOptions as BaseMaterialOptions } from 'cannon-es'
 import type { DependencyList, MutableRefObject, Ref, RefObject } from 'react'
 import type {
   AddRayMessage,
@@ -20,6 +20,11 @@ import type {
   SubscriptionTarget,
   VectorName,
 } from './setup'
+
+export type MaterialOptions =
+  | string
+  | undefined
+  | (Exclude<BaseMaterialOptions, string | undefined> & { name?: string })
 
 export type AtomicProps = {
   allowSleep: boolean
@@ -838,4 +843,25 @@ export function useRaycastVehicle(
     }
   }, deps)
   return [ref, api]
+}
+
+export function useContactMaterial(
+  materialA: MaterialOptions,
+  materialB: MaterialOptions,
+  options: ContactMaterialOptions,
+  deps: DependencyList = [],
+): void {
+  const { worker } = useContext(context)
+  const [uuid] = useState(() => MathUtils.generateUUID())
+
+  useEffect(() => {
+    worker.postMessage({
+      op: 'addContactMaterial',
+      uuid,
+      props: [materialA, materialB, options],
+    })
+    return () => {
+      worker.postMessage({ op: 'removeContactMaterial', uuid })
+    }
+  }, deps)
 }

--- a/src/propsToBody.js
+++ b/src/propsToBody.js
@@ -12,6 +12,9 @@ import {
   Trimesh,
   Vec3,
 } from 'cannon-es'
+/**
+ * @typedef { import('cannon-es').MaterialOptions } MaterialOptions
+ */
 
 const makeVec3 = ([x, y, z]) => new Vec3(x, y, z)
 const prepareSphere = (args) => (Array.isArray(args) ? args : [args])
@@ -47,13 +50,25 @@ function createShape(type, args) {
 }
 
 /**
- *
- * @param uuid {string}
- * @param props {BodyProps}
- * @param type {BodyShapeType}
- * @return {module:objects/Body.Body}
+ * @callback CreateMaterialCallback
+ * @param {MaterialOptions} materialOptions
+ * @returns {Material}
  */
-const propsToBody = (uuid, props, type) => {
+function createMaterialFromOptions(materialOptions) {
+  return new Material(materialOptions)
+}
+
+/**
+ * @function
+ * @param {Object} options
+ * @param {string} options.uuid
+ * @param {BodyProps} options.props
+ * @param {BodyShapeType} options.type
+ * @param {CreateMaterialCallback=} options.createMaterial
+ * @returns {Body}
+ */
+const propsToBody = (options) => {
+  const { uuid, props, type, createMaterial = createMaterialFromOptions } = options
   const {
     args = [],
     position = [0, 0, 0],
@@ -75,7 +90,7 @@ const propsToBody = (uuid, props, type) => {
     ...extra,
     mass: bodyType === 'Static' ? 0 : mass,
     type: bodyType ? Body[bodyType.toUpperCase()] : undefined,
-    material: material ? new Material(material) : undefined,
+    material: material ? createMaterial(material) : undefined,
   })
   body.uuid = uuid
 
@@ -90,7 +105,7 @@ const propsToBody = (uuid, props, type) => {
         position ? new Vec3(...position) : undefined,
         rotation ? new Quaternion().setFromEuler(...rotation) : undefined,
       )
-      if (material) shapeBody.material = new Material(material)
+      if (material) shapeBody.material = createMaterial(material)
       Object.assign(shapeBody, extra)
     })
   } else {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react'
 
-import type { RayOptions } from 'cannon-es'
+import type { ContactMaterialOptions, MaterialOptions, RayOptions } from 'cannon-es'
 import type { MutableRefObject } from 'react'
 import type { Object3D } from 'three'
 import type { ProviderProps, WorkerCollideEvent, WorkerRayhitEvent } from './Provider'
@@ -137,6 +137,13 @@ type SpringMessage =
   | SetSpringRestLengthMessage
   | SetSpringStiffnessMessage
 
+type AddContactMaterialMessage = WithUUID<
+  'addContactMaterial',
+  [materialA: MaterialOptions, materialB: MaterialOptions, options: ContactMaterialOptions]
+>
+type RemoveContactMaterialMessage = WithUUID<'removeContactMaterial'>
+type ContactMaterialMessage = AddContactMaterialMessage | RemoveContactMaterialMessage
+
 export type RayMode = 'Closest' | 'Any' | 'All'
 
 export type AddRayMessage = WithUUID<
@@ -244,6 +251,7 @@ type CannonMessage =
   | RotationMessage
   | SleepMessage
   | SpringMessage
+  | ContactMaterialMessage
   | SubscriptionMessage
   | VectorMessage
   | WakeUpMessage

--- a/src/worker.js
+++ b/src/worker.js
@@ -16,6 +16,8 @@ import {
   RaycastVehicle,
   GSSolver,
   SplitSolver,
+  Material,
+  ContactMaterial,
 } from 'cannon-es'
 import propsToBody from './propsToBody'
 
@@ -25,6 +27,7 @@ const state = {
   springs: {},
   springInstances: {},
   rays: {},
+  materials: {},
   world: new World(),
   config: { step: 1 / 60 },
   subscriptions: {},
@@ -45,6 +48,19 @@ function emitBeginContact({ bodyA, bodyB }) {
 function emitEndContact({ bodyA, bodyB }) {
   if (!bodyA || !bodyB) return
   self.postMessage({ op: 'event', type: 'collideEnd', bodyA: bodyA.uuid, bodyB: bodyB.uuid })
+}
+
+function getMaterialForOptions(materialOptions) {
+  if (typeof materialOptions === 'string') {
+    return (state.materials[materialOptions] =
+      state.materials[materialOptions] || new Material(materialOptions))
+  } else if (typeof materialOptions === 'object') {
+    const { name } = materialOptions
+    if (name) {
+      return (state.materials[name] = state.materials[name] || new Material(materialOptions))
+    }
+  }
+  return new Material(materialOptions)
 }
 
 self.onmessage = (e) => {
@@ -132,7 +148,13 @@ self.onmessage = (e) => {
     }
     case 'addBodies': {
       for (let i = 0; i < uuid.length; i++) {
-        const body = propsToBody(uuid[i], props[i], type)
+        const bodyProps = props[i]
+        const body = propsToBody({
+          uuid: uuid[i],
+          props: bodyProps,
+          type,
+          createMaterial: getMaterialForOptions,
+        })
         state.world.addBody(body)
 
         if (props[i].onCollide)
@@ -504,7 +526,22 @@ self.onmessage = (e) => {
       state.vehicles[uuid].setBrake(brake, wheelIndex)
       break
     }
-
+    case 'addContactMaterial': {
+      const [materialA, materialB, options] = props
+      const matA = getMaterialForOptions(materialA)
+      const matB = getMaterialForOptions(materialB)
+      const contactMaterial = new ContactMaterial(matA, matB, options)
+      contactMaterial.uuid = uuid
+      state.world.addContactMaterial(contactMaterial)
+      break
+    }
+    case 'removeContactMaterial': {
+      const cmIndex = state.world.contactmaterials.findIndex(({ uuid: thisId }) => thisId === uuid)
+      const cmat = state.world.contactmaterials[cmIndex]
+      state.world.contactmaterials.splice(cmIndex, 1)
+      state.world.contactMaterialTable.set(cmat.materials[0].id, cmat.materials[1].id, undefined)
+      break
+    }
     case 'wakeUp': {
       state.bodies[uuid].wakeUp()
       break


### PR DESCRIPTION
Friction (#64)
  - Inspired by: https://pmndrs.github.io/cannon-es/examples/friction
    - Source: https://github.com/pmndrs/cannon-es/blob/6f11e268d5e196f7f4f5908dbf60ae6365bd6ab6/examples/friction.html
    - Special thanks to https://github.com/pmndrs/use-cannon/pull/297
  - [x] Finalize/agree on the API
    - Material name: `useContactMaterial("string1", "string2", { ... })`
    - Material Options object: `useContactMaterial({ name: "string1" }, { name: "string2" }, { ... })`
      - [x] Update `MaterialOptions` type to include `name`
    - [x] Demo shows the cleanup works / can update the `ContactMaterial` properties
  - [x] Add `useContactMaterial` docs to README     

<!--
| Friction |
| --- |
|  https://use-cannon-git-fork-glavin001-feat-more-examples-pmndrs.vercel.app/#/demo/Friction |
| ![image](https://user-images.githubusercontent.com/1885333/147134375-80159076-f25c-4839-a3d3-dc1f7c8d0b47.png) |
-->

## Demo

https://use-cannon-git-fork-glavin001-feat-contact-material-pmndrs.vercel.app/#/demo/Friction

![image](https://user-images.githubusercontent.com/1885333/148629725-5a57beb7-78d6-429f-a9a1-a93946cd84bf.png)
