### PR TITLE
Add Tear constraint example

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ interface CompoundBodyProps extends BodyProps {
 
 interface ConstraintOptns {
   maxForce?: number
+  maxMultiplier?: number
   collideConnected?: boolean
   wakeUpBodies?: boolean
 }

--- a/examples/src/demos/Chain.tsx
+++ b/examples/src/demos/Chain.tsx
@@ -1,81 +1,169 @@
-import { createContext, createRef, useContext } from 'react'
+import { createContext, createRef, useCallback, useContext, useMemo, useState } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber'
-import { Physics, useSphere, useBox, useConeTwistConstraint } from '@react-three/cannon'
+import { Physics, useSphere, useBox, useConeTwistConstraint, useCylinder } from '@react-three/cannon'
 
 import type { PropsWithChildren } from 'react'
-import type { Triplet } from '@react-three/cannon'
+import type { Triplet, CylinderArgs } from '@react-three/cannon'
 import type { Object3D } from 'three'
+import { Color } from 'three'
 
-const parent = createContext(createRef<Object3D>())
+const maxMultiplierExamples = [0, 500, 1000, 1500, undefined]
 
-const ChainLink = ({ children }: PropsWithChildren<{}>) => {
-  const parentRef = useContext(parent)
-  const chainSize: Triplet = [0.15, 1, 0.15]
-  const [ref] = useBox(() => ({
+const parent = createContext({
+  ref: createRef<Object3D>(),
+  position: [0, 0, 0] as Triplet,
+})
+
+const ChainLink = ({
+  children,
+  args = [0.5, 0.5, 2, 16],
+  maxMultiplier,
+  color = 'white',
+  ...props
+}: PropsWithChildren<{
+  args?: CylinderArgs
+  maxMultiplier?: number
+  color?: Color | string
+}>) => {
+  const { ref: parentRef, position: parentPos } = useContext(parent)
+  const height = args[2] ?? 2
+  const initialPosition: Triplet = [parentPos[0], parentPos[1] - height, parentPos[2]]
+  const [ref] = useCylinder(() => ({
     mass: 1,
     linearDamping: 0.8,
-    args: chainSize,
+    args,
+    ...props,
+    position: initialPosition,
   }))
   useConeTwistConstraint(parentRef, ref, {
-    pivotA: [0, -chainSize[1] / 2, 0],
-    pivotB: [0, chainSize[1] / 2, 0],
+    pivotA: [0, -height / 2, 0],
+    pivotB: [0, height / 2, 0],
     axisA: [0, 1, 0],
     axisB: [0, 1, 0],
     twistAngle: 0,
     angle: Math.PI / 8,
+    maxMultiplier,
   })
   return (
     <>
       <mesh ref={ref}>
-        <cylinderBufferGeometry args={[chainSize[0], chainSize[0], chainSize[1], 8]} />
-        <meshStandardMaterial />
+        <cylinderBufferGeometry args={args} />
+        <meshStandardMaterial color={color} />
       </mesh>
-      <parent.Provider value={ref}>{children}</parent.Provider>
+      <parent.Provider value={{ ref, position: initialPosition }}>{children}</parent.Provider>
     </>
   )
 }
 
-const Handle = ({ children, radius }: PropsWithChildren<{ radius: number }>) => {
-  const [ref, { position }] = useSphere(() => ({ type: 'Static', args: [radius], position: [0, 0, 0] }))
+function Chain({
+  maxMultiplier,
+  length,
+  children,
+}: PropsWithChildren<{ maxMultiplier?: number; length: number }>) {
+  const color = useMemo(() => {
+    if (maxMultiplier === undefined) return 'white'
+    const maxExample = Math.max(...maxMultiplierExamples.filter(notUndefined))
+    const red = Math.floor(Math.min(100, (maxMultiplier / maxExample) * 100))
+    return new Color(`rgb(${red}%, 0%, ${100 - red}%)`)
+  }, [maxMultiplier])
+  return (
+    <>
+      {Array.from({ length }).reduce((acc: React.ReactNode) => {
+        return (
+          <ChainLink maxMultiplier={maxMultiplier} color={color}>
+            {acc}
+          </ChainLink>
+        )
+      }, children)}
+    </>
+  )
+}
+
+function notUndefined<T>(value: T | undefined): value is T {
+  return value !== undefined
+}
+
+const PointerHandle = ({ children, size }: PropsWithChildren<{ size: number }>) => {
+  const initialPosition: Triplet = [0, 0, 0]
+  const args: Triplet = [size, size, size * 2]
+  const [ref, { position }] = useBox(() => ({ type: 'Kinematic', args, position: initialPosition }))
   useFrame(({ mouse: { x, y }, viewport: { height, width } }) =>
     position.set((x * width) / 2, (y * height) / 2, 0),
   )
   return (
     <group>
       <mesh ref={ref}>
+        <boxBufferGeometry args={args} />
+        <meshStandardMaterial />
+      </mesh>
+      <parent.Provider value={{ ref, position: initialPosition }}>{children}</parent.Provider>
+    </group>
+  )
+}
+
+const StaticHandle = ({
+  children,
+  radius,
+  position,
+}: PropsWithChildren<{ radius: number; position: Triplet }>) => {
+  const [ref] = useSphere(() => ({ type: 'Static', args: [radius], position }))
+  return (
+    <group>
+      <mesh ref={ref}>
         <sphereBufferGeometry args={[radius, 64, 64]} />
         <meshStandardMaterial />
       </mesh>
-      <parent.Provider value={ref}>{children}</parent.Provider>
+      <parent.Provider value={{ ref, position }}>{children}</parent.Provider>
     </group>
   )
 }
 
 const ChainScene = () => {
+  const [resetCount, setResetCount] = useState(0)
+  const reset = useCallback(() => {
+    setResetCount((prev) => prev + 1)
+  }, [])
+  const separation = 4
   return (
-    <Canvas shadows camera={{ position: [0, 5, 20], fov: 50 }}>
-      <color attach="background" args={['#171720']} />
-      <ambientLight intensity={0.5} />
-      <pointLight position={[-10, -10, -10]} />
-      <spotLight position={[10, 10, 10]} angle={0.3} penumbra={1} intensity={1} castShadow />
-      <Physics gravity={[0, -40, 0]} allowSleep={false}>
-        <Handle radius={0.5}>
-          <ChainLink>
-            <ChainLink>
-              <ChainLink>
-                <ChainLink>
-                  <ChainLink>
-                    <ChainLink>
-                      <ChainLink />
-                    </ChainLink>
-                  </ChainLink>
-                </ChainLink>
-              </ChainLink>
-            </ChainLink>
-          </ChainLink>
-        </Handle>
-      </Physics>
-    </Canvas>
+    <>
+      <Canvas shadows camera={{ position: [0, 5, 20], fov: 50 }} onPointerMissed={reset}>
+        <color attach="background" args={['#171720']} />
+        <ambientLight intensity={0.5} />
+        <pointLight position={[-10, -10, -10]} />
+        <spotLight position={[10, 10, 10]} angle={0.8} penumbra={1} intensity={1} castShadow />
+        <Physics gravity={[0, -40, 0]} allowSleep={false}>
+          <PointerHandle size={1.5}>
+            <Chain length={7} />
+          </PointerHandle>
+          {maxMultiplierExamples.map((maxMultiplier, index) => (
+            <StaticHandle
+              key={`${resetCount}-${maxMultiplier}`}
+              radius={1.5}
+              position={[(maxMultiplierExamples.length * -separation) / 2 + index * separation, 8, 0]}
+            >
+              <Chain maxMultiplier={maxMultiplier} length={8} />
+            </StaticHandle>
+          ))}
+        </Physics>
+      </Canvas>
+      <div
+        style={{
+          position: 'absolute',
+          top: 20,
+          left: 50,
+          color: 'white',
+          fontSize: '1.2em',
+        }}
+      >
+        <pre>
+          * move pointer to move the box
+          <br />
+          and break the chain constraints,
+          <br />
+          click to reset
+        </pre>
+      </div>
+    </>
   )
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -139,6 +139,7 @@ export type ConstraintTypes = 'PointToPoint' | 'ConeTwist' | 'Distance' | 'Lock'
 
 export interface ConstraintOptns {
   maxForce?: number
+  maxMultiplier?: number
   collideConnected?: boolean
   wakeUpBodies?: boolean
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -24,6 +24,7 @@ const state = {
   vehicles: {},
   springs: {},
   springInstances: {},
+  constraints: {},
   rays: {},
   world: new World(),
   config: { step: 1 / 60 },
@@ -276,7 +277,7 @@ self.onmessage = (e) => {
       break
     case 'addConstraint': {
       const [bodyA, bodyB, optns] = props
-      let { pivotA, pivotB, axisA, axisB, ...options } = optns
+      let { pivotA, pivotB, axisA, axisB, maxMultiplier, ...options } = optns
 
       // is there a better way to enforce defaults?
       pivotA = Array.isArray(pivotA) ? new Vec3(...pivotA) : undefined
@@ -331,12 +332,29 @@ self.onmessage = (e) => {
       }
       constraint.uuid = uuid
       state.world.addConstraint(constraint)
+
+      if (maxMultiplier !== undefined) {
+        const postStepConstraint = () => {
+          // The multiplier is proportional to how much force is added to the bodies by the constraint.
+          // If this exceeds a limit the constraint is disabled.
+          const multiplier = Math.abs(constraint.equations[0].multiplier)
+          if (multiplier > maxMultiplier) {
+            constraint.disable()
+          }
+        }
+        state.constraints[uuid] = postStepConstraint
+        state.world.addEventListener('postStep', state.constraints[uuid])
+      }
       break
     }
     case 'removeConstraint':
       state.world.constraints
         .filter(({ uuid: thisId }) => thisId === uuid)
         .map((c) => state.world.removeConstraint(c))
+      if (state.constraints[uuid]) {
+        state.world.removeEventListener('postStep', state.constraints[uuid])
+        delete state.constraints[uuid]
+      }
       break
 
     case 'enableConstraint':


### PR DESCRIPTION
Add maxMultipler threshold to constraints.

Inspired by https://github.com/pmndrs/cannon-es/blob/6f11e268d5e196f7f4f5908dbf60ae6365bd6ab6/examples/tear.html

- [x] Tear constraint
    - [x] Add `maxMultiplier` option to all constraints, which disables constraint when threshold is exceeded
      - [x] Only add `postStep` listener if `maxMultiplier` set / not `undefined`
    - Inspired by: https://pmndrs.github.io/cannon-es/examples/tear
      - Source: https://github.com/pmndrs/cannon-es/blob/6f11e268d5e196f7f4f5908dbf60ae6365bd6ab6/examples/tear.html
  - [x] Update docs
    - [x] TypeScript interface
    - [x] README
  - [x] Merged Chain & Tear into a single example/demo
    - [x] Single file that demonstrate a feature. We should be able to take that file put it in a sandbox with minimal setup.
    - [x] Includes pointer position (from original `Chain`)
    - [x] Includes multiple `maxMultiplier` values
      - [x] Color of chain indicates the value (`0 = blue`/easily break, `1500 = red`/harder to break, `white = undefined`/won't break)
    - [x] Click to reset torn chains / re-enable constraints

<!--
| Tear |
| --- |
| https://use-cannon-git-fork-glavin001-feat-more-examples-pmndrs.vercel.app/#/demo/Tear |
| ![image](https://user-images.githubusercontent.com/1885333/146724027-6a07dd8e-2624-4954-b097-7a16ef49aabb.png) |
-->

## Demo

https://use-cannon-git-fork-glavin001-feat-constraint-max-e97738-pmndrs.vercel.app/#/demo/Chain

Initially:

![image](https://user-images.githubusercontent.com/1885333/148499806-9888991e-3aaf-4a35-a060-82ae81c04bc3.png)

After breaking some chain constraints:

![image](https://user-images.githubusercontent.com/1885333/148499921-cf94abf4-e6d0-4b1e-a904-c935eaede06c.png)
