### PR TITLE
Fix RaycastVehicle example

### DIFF
--- a/examples/src/demos/RaycastVehicle/Vehicle.tsx
+++ b/examples/src/demos/RaycastVehicle/Vehicle.tsx
@@ -51,7 +51,6 @@ function Vehicle({
     dampingRelaxation: 10,
     dampingCompression: 4.4,
     axleLocal: [-1, 0, 0], // This is inverted for asymmetrical wheel models (left v. right sided)
-    chassisConnectionPointLocal: [1, 0, 1],
     useCustomSlidingRotationalSpeed: true,
     customSlidingRotationalSpeed: -30,
     frictionSlip: 2,
@@ -95,9 +94,6 @@ function Vehicle({
     chassisBody,
     wheels,
     wheelInfos: [wheelInfo1, wheelInfo2, wheelInfo3, wheelInfo4],
-    indexForwardAxis: 2,
-    indexRightAxis: 0,
-    indexUpAxis: 1,
   }))
 
   useEffect(() => vehicleApi.sliding.subscribe((v) => console.log('sliding', v)), [])

--- a/examples/src/demos/RaycastVehicle/Wheel.tsx
+++ b/examples/src/demos/RaycastVehicle/Wheel.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react'
 import { useGLTF } from '@react-three/drei'
-import { useCylinder } from '@react-three/cannon'
+import { useCompoundBody } from '@react-three/cannon'
 
 import type { BufferGeometry, Material, Object3D } from 'three'
 import type { GLTF } from 'three-stdlib/loaders/GLTFLoader'
@@ -22,24 +22,24 @@ type WheelProps = CylinderProps & {
 
 export const Wheel = forwardRef<Object3D, WheelProps>(({ radius = 0.7, leftSide, ...props }, ref) => {
   const { nodes, materials } = useGLTF('/wheel.glb') as WheelGLTF
-  useCylinder(
+  useCompoundBody(
     () => ({
       mass: 1,
       type: 'Kinematic',
       material: 'wheel',
       collisionFilterGroup: 0,
-      args: [radius, radius, 0.5, 16],
+      shapes: [{ type: 'Cylinder', rotation: [0, 0, -Math.PI / 2], args: [radius, radius, 0.5, 16] }],
       ...props,
     }),
     ref,
   )
   return (
-    <mesh ref={ref}>
-      <mesh rotation={[0, 0, ((leftSide ? 1 : -1) * Math.PI) / 2]}>
+    <group ref={ref}>
+      <group rotation={[0, 0, ((leftSide ? 1 : -1) * Math.PI) / 2]}>
         <mesh material={materials.Rubber} geometry={nodes.wheel_1.geometry} />
         <mesh material={materials.Steel} geometry={nodes.wheel_2.geometry} />
         <mesh material={materials.Chrom} geometry={nodes.wheel_3.geometry} />
-      </mesh>
-    </mesh>
+      </group>
+    </group>
   )
 })

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -808,9 +808,9 @@ export function useRaycastVehicle(
         chassisBodyUUID,
         wheelUUIDs,
         raycastVehicleProps.wheelInfos,
-        raycastVehicleProps?.indexForwardAxis || 2,
-        raycastVehicleProps?.indexRightAxis || 0,
-        raycastVehicleProps?.indexUpAxis || 1,
+        raycastVehicleProps?.indexRightAxis ?? 2,
+        raycastVehicleProps?.indexForwardAxis ?? 0,
+        raycastVehicleProps?.indexUpAxis ?? 1,
       ],
     })
     return () => {


### PR DESCRIPTION
Fixes #300

https://user-images.githubusercontent.com/7217420/147679112-a19e5816-ee9f-4907-acdc-e57a7014de9a.mov

Currently, the wheels in the useRaycastVehicle are orientated up (the debugger in #300 shows correctly what's going on).

This is because from v0.10.0 of cannon-es, the cylinder is created vertically, just like in three.js.
So [you need to rotate the cylinder by `-Math.PI / 2`](https://github.com/pmndrs/cannon-es/blob/cf4e6e46c48c4176d0e9b6dd9b5d0e49d5a3b33e/examples/raycast_vehicle.html#L74) to put it horizontally. I did this via `useCompoundBody`.

Also, the `indexRightAxis`, `indexForwardAxis`, `indexUpAxis` order was somehow messed up, [it has to reflect the values set here](https://github.com/pmndrs/cannon-es/blob/cf4e6e46c48c4176d0e9b6dd9b5d0e49d5a3b33e/src/objects/RaycastVehicle.ts#L52-L54).

The `||` operator had an issue as well, it would result in falsy if `0` was passed.