### PR TITLE
Add missing worker 'setMaterial' op handler

### DIFF
--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -207,6 +207,9 @@ self.onmessage = ({ data: { op, positions, props, quaternions, type, uuid } }) =
       state.bodies[uuid].mass = props
       state.bodies[uuid].updateMassProperties()
       break
+    case 'setMaterial':
+      state.bodies[uuid].material = props ? createMaterial(props) : undefined
+      break
     case 'setLinearDamping':
       state.bodies[uuid].linearDamping = props
       break


### PR DESCRIPTION
- Add missing worker `setMaterial` op handler
  - The set material api was already returned from body hooks, but the worker had no handling for it
- addresses #339 

e.g.
```typescript
const [ref, api] = useBox(...)
api.material.set({ friction: 1 })
```