### PR TITLE
Create API layer between hooks and cannon web worker

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,41 @@
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/member-ordering": [
           "error",
-          { "default": { "order": "alphabetically-case-insensitive" } }
+          {
+            "default": {
+              "order": "alphabetically-case-insensitive"
+            },
+            "classes": {
+              "order": "alphabetically-case-insensitive",
+              "memberTypes": [
+                "public-static-field",
+                "protected-static-field",
+                "private-static-field",
+                "public-instance-field",
+                "public-decorated-field",
+                "public-abstract-field",
+                "protected-instance-field",
+                "protected-decorated-field",
+                "protected-abstract-field",
+                "private-instance-field",
+                "private-decorated-field",
+                "private-abstract-field",
+                "static-field",
+                "public-field",
+                "instance-field",
+                "protected-field",
+                "private-field",
+                "abstract-field",
+                "constructor",
+                "public-static-method",
+                "protected-static-method",
+                "private-static-method",
+                "public-method",
+                "protected-method",
+                "private-method"
+              ]
+            }
+          }
         ],
         "@typescript-eslint/no-namespace": ["error", { "allowDeclarations": true }],
         "@typescript-eslint/no-non-null-assertion": "off",

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -350,10 +350,11 @@
   integrity sha512-W/YMJMX35XgGGzX0gKORBTwnvQ+1loDOFN3XlZkW5fgpEY+7VkRUpPyqPWXQr3n6lHrsLmHIGdpznqZi54ACTQ==
 
 "@react-three/cannon@file:..":
-  version "4.4.0"
+  version "4.6.1"
   dependencies:
     cannon-es "^0.18.0"
     cannon-es-debugger "^1.0.0"
+    events "^3.3.0"
 
 "@react-three/drei@^8.3.1":
   version "8.3.1"
@@ -853,6 +854,11 @@ estree-walker@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 fast-deep-equal@^3.1.3:
   version "3.1.3"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "cannon-es": "^0.18.0",
-    "cannon-es-debugger": "^1.0.0"
+    "cannon-es-debugger": "^1.0.0",
+    "events": "^3.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.5",

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,24 +1,91 @@
-import type { ContactMaterialOptions, MaterialOptions, RayOptions } from 'cannon-es'
+import type {
+  ContactMaterial,
+  ContactMaterialOptions,
+  MaterialOptions,
+  RayOptions as RayOptionsImpl,
+  Shape,
+} from 'cannon-es'
 import type { MutableRefObject } from 'react'
 import { createContext } from 'react'
 import type { Object3D } from 'three'
+import type { CannonWorker } from 'worker/cannon-worker'
 
-import type {
-  AtomicProps,
-  BodyProps,
-  BodyShapeType,
-  ConstraintTypes,
-  Quad,
-  SpringOptns,
-  Triplet,
-  WheelInfoOptions,
-} from './hooks'
-import type { ProviderProps, WorkerCollideEvent, WorkerRayhitEvent } from './Provider'
+import type { AtomicProps, BodyProps, BodyShapeType } from './hooks'
+
+export type Triplet = [x: number, y: number, z: number]
+export type Quad = [x: number, y: number, z: number, w: number]
 
 export type Broadphase = 'Naive' | 'SAP'
 export type Solver = 'GS' | 'Split'
 export type Buffers = { positions: Float32Array; quaternions: Float32Array }
 export type Refs = { [uuid: string]: Object3D }
+
+export type ConstraintTypes = 'PointToPoint' | 'ConeTwist' | 'Distance' | 'Lock'
+
+export interface ConstraintOptns {
+  collideConnected?: boolean
+  maxForce?: number
+  maxMultiplier?: number
+  wakeUpBodies?: boolean
+}
+
+export interface PointToPointConstraintOpts extends ConstraintOptns {
+  pivotA: Triplet
+  pivotB: Triplet
+}
+
+export interface ConeTwistConstraintOpts extends ConstraintOptns {
+  angle?: number
+  axisA?: Triplet
+  axisB?: Triplet
+  pivotA?: Triplet
+  pivotB?: Triplet
+  twistAngle?: number
+}
+export interface DistanceConstraintOpts extends ConstraintOptns {
+  distance?: number
+}
+
+export interface HingeConstraintOpts extends ConstraintOptns {
+  axisA?: Triplet
+  axisB?: Triplet
+  pivotA?: Triplet
+  pivotB?: Triplet
+}
+
+export type LockConstraintOpts = ConstraintOptns
+
+export interface SpringOptns {
+  damping?: number
+  localAnchorA?: Triplet
+  localAnchorB?: Triplet
+  restLength?: number
+  stiffness?: number
+  worldAnchorA?: Triplet
+  worldAnchorB?: Triplet
+}
+
+export type RayOptions = Omit<AddRayMessage['props'], 'mode'>
+
+export interface WheelInfoOptions {
+  axleLocal?: Triplet
+  chassisConnectionPointLocal?: Triplet
+  customSlidingRotationalSpeed?: number
+  dampingCompression?: number
+  dampingRelaxation?: number
+  directionLocal?: Triplet
+  frictionSlip?: number
+  isFrontWheel?: boolean
+  maxSuspensionForce?: number
+  maxSuspensionTravel?: number
+  radius?: number
+  rollInfluence?: number
+  sideAcceleration?: number
+  suspensionRestLength?: number
+  suspensionStiffness?: number
+  useCustomSlidingRotationalSpeed?: boolean
+}
+
 type WorkerContact = WorkerCollideEvent['data']['contact']
 export type CollideEvent = Omit<WorkerCollideEvent['data'], 'body' | 'target' | 'contact'> & {
   body: Object3D
@@ -96,17 +163,16 @@ export type SubscriptionName = typeof subscriptionNames[number]
 export type SetOpName<T extends AtomicName | VectorName | WorldPropName | 'quaternion' | 'rotation'> =
   `set${Capitalize<T>}`
 
-type Operation<T extends string, P> = { op: T } & (P extends void ? {} : { props: P })
-type WithUUID<T extends string, P = void> = Operation<T, P> & { uuid: string }
-type WithUUIDs<T extends string, P = void> = Operation<T, P> & { uuid: string[] }
+type Operation<T extends string, P> = { op: T } & (P extends null ? {} : { props: P })
+type WithUUID<T extends string, P = null> = Operation<T, P> & { uuid: string }
+type WithUUIDs<T extends string, P = null> = Operation<T, P> & { uuid: string[] }
 
-type AddConstraintMessage = WithUUID<'addConstraint', [uuidA: string, uuidB: string, options: {}]> & {
+export type AddConstraintMessage = WithUUID<'addConstraint', [uuidA: string, uuidB: string, options: {}]> & {
   type: 'Hinge' | ConstraintTypes
 }
-
-type DisableConstraintMessage = WithUUID<'disableConstraint'>
-type EnableConstraintMessage = WithUUID<'enableConstraint'>
-type RemoveConstraintMessage = WithUUID<'removeConstraint'>
+export type DisableConstraintMessage = WithUUID<'disableConstraint'>
+export type EnableConstraintMessage = WithUUID<'enableConstraint'>
+export type RemoveConstraintMessage = WithUUID<'removeConstraint'>
 
 type ConstraintMessage =
   | AddConstraintMessage
@@ -114,10 +180,10 @@ type ConstraintMessage =
   | EnableConstraintMessage
   | RemoveConstraintMessage
 
-type DisableConstraintMotorMessage = WithUUID<'disableConstraintMotor'>
-type EnableConstraintMotorMessage = WithUUID<'enableConstraintMotor'>
-type SetConstraintMotorMaxForce = WithUUID<'setConstraintMotorMaxForce', number>
-type SetConstraintMotorSpeed = WithUUID<'setConstraintMotorSpeed', number>
+export type DisableConstraintMotorMessage = WithUUID<'disableConstraintMotor'>
+export type EnableConstraintMotorMessage = WithUUID<'enableConstraintMotor'>
+export type SetConstraintMotorMaxForce = WithUUID<'setConstraintMotorMaxForce', number>
+export type SetConstraintMotorSpeed = WithUUID<'setConstraintMotorSpeed', number>
 
 type ConstraintMotorMessage =
   | DisableConstraintMotorMessage
@@ -125,12 +191,12 @@ type ConstraintMotorMessage =
   | SetConstraintMotorSpeed
   | SetConstraintMotorMaxForce
 
-type AddSpringMessage = WithUUID<'addSpring', [uuidA: string, uuidB: string, options: SpringOptns]>
-type RemoveSpringMessage = WithUUID<'removeSpring'>
+export type AddSpringMessage = WithUUID<'addSpring', [uuidA: string, uuidB: string, options: SpringOptns]>
+export type RemoveSpringMessage = WithUUID<'removeSpring'>
 
-type SetSpringDampingMessage = WithUUID<'setSpringDamping', number>
-type SetSpringRestLengthMessage = WithUUID<'setSpringRestLength', number>
-type SetSpringStiffnessMessage = WithUUID<'setSpringStiffness', number>
+export type SetSpringDampingMessage = WithUUID<'setSpringDamping', number>
+export type SetSpringRestLengthMessage = WithUUID<'setSpringRestLength', number>
+export type SetSpringStiffnessMessage = WithUUID<'setSpringStiffness', number>
 
 type SpringMessage =
   | AddSpringMessage
@@ -143,7 +209,7 @@ export type AddContactMaterialMessage = WithUUID<
   'addContactMaterial',
   [materialA: MaterialOptions, materialB: MaterialOptions, options: ContactMaterialOptions]
 >
-type RemoveContactMaterialMessage = WithUUID<'removeContactMaterial'>
+export type RemoveContactMaterialMessage = WithUUID<'removeContactMaterial'>
 type ContactMaterialMessage = AddContactMaterialMessage | RemoveContactMaterialMessage
 
 export type RayMode = 'Closest' | 'Any' | 'All'
@@ -155,15 +221,15 @@ export type AddRayMessage = WithUUID<
     mode: RayMode
     to?: Triplet
   } & Pick<
-    RayOptions,
+    RayOptionsImpl,
     'checkCollisionResponse' | 'collisionFilterGroup' | 'collisionFilterMask' | 'skipBackfaces'
   >
 >
-type RemoveRayMessage = WithUUID<'removeRay'>
+export type RemoveRayMessage = WithUUID<'removeRay'>
 
 type RayMessage = AddRayMessage | RemoveRayMessage
 
-type AddRaycastVehicleMessage = WithUUIDs<
+export type AddRaycastVehicleMessage = WithUUIDs<
   'addRaycastVehicle',
   [
     chassisBodyUUID: string,
@@ -174,14 +240,17 @@ type AddRaycastVehicleMessage = WithUUIDs<
     indexUpAxis: number,
   ]
 >
-type RemoveRaycastVehicleMessage = WithUUIDs<'removeRaycastVehicle'>
+export type RemoveRaycastVehicleMessage = WithUUIDs<'removeRaycastVehicle'>
 
-type ApplyRaycastVehicleEngineForceMessage = WithUUID<
+export type ApplyRaycastVehicleEngineForceMessage = WithUUID<
   'applyRaycastVehicleEngineForce',
   [value: number, wheelIndex: number]
 >
-type SetRaycastVehicleBrakeMessage = WithUUID<'setRaycastVehicleBrake', [brake: number, wheelIndex: number]>
-type SetRaycastVehicleSteeringValueMessage = WithUUID<
+export type SetRaycastVehicleBrakeMessage = WithUUID<
+  'setRaycastVehicleBrake',
+  [brake: number, wheelIndex: number]
+>
+export type SetRaycastVehicleSteeringValueMessage = WithUUID<
   'setRaycastVehicleSteeringValue',
   [value: number, wheelIndex: number]
 >
@@ -193,16 +262,19 @@ type RaycastVehicleMessage =
   | SetRaycastVehicleBrakeMessage
   | SetRaycastVehicleSteeringValueMessage
 
-type AtomicMessage = WithUUID<SetOpName<AtomicName>, any>
-type QuaternionMessage = WithUUID<SetOpName<'quaternion'>, Quad>
-type RotationMessage = WithUUID<SetOpName<'rotation'>, Triplet>
-type VectorMessage = WithUUID<SetOpName<VectorName>, Triplet>
+export type AtomicMessage<T extends AtomicName | undefined = undefined> = WithUUID<
+  SetOpName<AtomicName>,
+  T extends AtomicName ? PropValue<T> : any
+>
+export type QuaternionMessage = WithUUID<SetOpName<'quaternion'>, Quad>
+export type RotationMessage = WithUUID<SetOpName<'rotation'>, Triplet>
+export type VectorMessage = WithUUID<SetOpName<VectorName>, Triplet>
 
-type ApplyForceMessage = WithUUID<'applyForce', [force: Triplet, worldPoint: Triplet]>
-type ApplyImpulseMessage = WithUUID<'applyImpulse', [impulse: Triplet, worldPoint: Triplet]>
-type ApplyLocalForceMessage = WithUUID<'applyLocalForce', [force: Triplet, localPoint: Triplet]>
-type ApplyLocalImpulseMessage = WithUUID<'applyLocalImpulse', [impulse: Triplet, localPoint: Triplet]>
-type ApplyTorque = WithUUID<'applyTorque', [torque: Triplet]>
+export type ApplyForceMessage = WithUUID<'applyForce', [force: Triplet, worldPoint: Triplet]>
+export type ApplyImpulseMessage = WithUUID<'applyImpulse', [impulse: Triplet, worldPoint: Triplet]>
+export type ApplyLocalForceMessage = WithUUID<'applyLocalForce', [force: Triplet, localPoint: Triplet]>
+export type ApplyLocalImpulseMessage = WithUUID<'applyLocalImpulse', [impulse: Triplet, localPoint: Triplet]>
+export type ApplyTorque = WithUUID<'applyTorque', [torque: Triplet]>
 
 type ApplyMessage =
   | ApplyForceMessage
@@ -215,17 +287,17 @@ type SerializableBodyProps = {
   onCollide: boolean
 }
 
-type AddBodiesMessage = WithUUIDs<'addBodies', SerializableBodyProps[]> & { type: BodyShapeType }
-type RemoveBodiesMessage = WithUUIDs<'removeBodies'>
+export type AddBodiesMessage = WithUUIDs<'addBodies', SerializableBodyProps[]> & { type: BodyShapeType }
+export type RemoveBodiesMessage = WithUUIDs<'removeBodies'>
 
 type BodiesMessage = AddBodiesMessage | RemoveBodiesMessage
 
-type SleepMessage = WithUUID<'sleep'>
-type WakeUpMessage = WithUUID<'wakeUp'>
+export type SleepMessage = WithUUID<'sleep'>
+export type WakeUpMessage = WithUUID<'wakeUp'>
 
 export type SubscriptionTarget = 'bodies' | 'vehicles'
 
-type SubscribeMessage = WithUUID<
+export type SubscribeMessage = WithUUID<
   'subscribe',
   {
     id: number
@@ -233,44 +305,147 @@ type SubscribeMessage = WithUUID<
     type: SubscriptionName
   }
 >
-type UnsubscribeMessage = Operation<'unsubscribe', number>
+export type UnsubscribeMessage = Operation<'unsubscribe', number>
 
 type SubscriptionMessage = SubscribeMessage | UnsubscribeMessage
 
+export type Observation = { [K in AtomicName]: [id: number, value: PropValue<K>, type: K] }[AtomicName]
+
+export type WorkerFrameMessage = {
+  data: Buffers & {
+    active: boolean
+    bodies?: string[]
+    observations: Observation[]
+    op: 'frame'
+  }
+}
+
+export type WorkerCollideEvent = {
+  data: {
+    body: string
+    collisionFilters: {
+      bodyFilterGroup: number
+      bodyFilterMask: number
+      targetFilterGroup: number
+      targetFilterMask: number
+    }
+    contact: {
+      bi: string
+      bj: string
+      /** Normal of the contact, relative to the colliding body */
+      contactNormal: number[]
+      /** Contact point in world space */
+      contactPoint: number[]
+      id: string
+      impactVelocity: number
+      ni: number[]
+      ri: number[]
+      rj: number[]
+    }
+    op: 'event'
+    target: string
+    type: 'collide'
+  }
+}
+
+export type WorkerRayhitEvent = {
+  data: {
+    body: string | null
+    distance: number
+    hasHit: boolean
+    hitFaceIndex: number
+    hitNormalWorld: number[]
+    hitPointWorld: number[]
+    op: 'event'
+    ray: {
+      collisionFilterGroup: number
+      collisionFilterMask: number
+      direction: number[]
+      from: number[]
+      to: number[]
+      uuid: string
+    }
+    rayFromWorld: number[]
+    rayToWorld: number[]
+    shape: (Omit<Shape, 'body'> & { body: string }) | null
+    shouldStop: boolean
+    type: 'rayhit'
+  }
+}
+export type WorkerCollideBeginEvent = {
+  data: {
+    bodyA: string
+    bodyB: string
+    op: 'event'
+    type: 'collideBegin'
+  }
+}
+export type WorkerCollideEndEvent = {
+  data: {
+    bodyA: string
+    bodyB: string
+    op: 'event'
+    type: 'collideEnd'
+  }
+}
+export type WorkerEventMessage =
+  | WorkerCollideBeginEvent
+  | WorkerCollideEndEvent
+  | WorkerCollideEvent
+  | WorkerRayhitEvent
+
+export type IncomingWorkerMessage = WorkerEventMessage | WorkerFrameMessage
+
 export type WorldPropName = 'axisIndex' | 'broadphase' | 'gravity' | 'iterations' | 'tolerance'
 
-type WorldMessage<T extends WorldPropName> = Operation<SetOpName<T>, Required<ProviderProps[T]>>
+export type DefaultContactMaterial = Partial<
+  Pick<
+    ContactMaterial,
+    | 'contactEquationRelaxation'
+    | 'contactEquationStiffness'
+    | 'friction'
+    | 'frictionEquationRelaxation'
+    | 'frictionEquationStiffness'
+    | 'restitution'
+  >
+>
 
-export type InitProps = {
-  allowSleep?: boolean
-  axisIndex?: number
-  broadphase?: Broadphase
-  defaultContactMaterial?: ContactMaterialOptions
-  gravity?: Triplet
-  iterations?: number
-  quatNormalizeFast?: boolean
-  quatNormalizeSkip?: number
-  solver?: Solver
-  tolerance?: number
+export type InitMessage = Operation<
+  'init',
+  {
+    allowSleep: boolean
+    axisIndex: number
+    broadphase: Broadphase
+    defaultContactMaterial: DefaultContactMaterial
+    gravity: Triplet
+    iterations: number
+    quatNormalizeFast: boolean
+    quatNormalizeSkip: number
+    solver: Solver
+    tolerance: number
+  }
+>
+
+export type StepMessage = Operation<
+  'step',
+  {
+    dt?: number
+    maxSubSteps?: number
+    stepSize: number
+  }
+> & {
+  positions: Float32Array
+  quaternions: Float32Array
 }
 
-type InitMessage = Operation<'init', InitProps>
+type WorldMessage<T extends WorldPropName> = Operation<SetOpName<T>, Required<InitMessage['props'][T]>>
 
-type StepProps = {
-  maxSubSteps?: number
-  stepSize: number
-  timeSinceLastCalled?: number
-}
-
-type StepMessage = Operation<'step', StepProps>
-
-type CannonMessage =
+export type CannonMessage =
   | ApplyMessage
   | AtomicMessage
   | BodiesMessage
   | ConstraintMessage
   | ConstraintMotorMessage
-  | ContactMaterialMessage
   | InitMessage
   | QuaternionMessage
   | RaycastVehicleMessage
@@ -279,19 +454,85 @@ type CannonMessage =
   | SleepMessage
   | SpringMessage
   | StepMessage
+  | ContactMaterialMessage
   | SubscriptionMessage
   | VectorMessage
   | WakeUpMessage
   | WorldMessage<WorldPropName>
 
-export interface CannonWorker extends Worker {
-  postMessage(message: CannonMessage, transfer: Transferable[]): void
-  postMessage(message: CannonMessage, options?: StructuredSerializeOptions): void
+type CannonMessageMap = {
+  addBodies: AddBodiesMessage
+  addConstraint: AddConstraintMessage
+  addContactMaterial: AddContactMaterialMessage
+  addRay: AddRayMessage
+  addRaycastVehicle: AddRaycastVehicleMessage
+  addSpring: AddSpringMessage
+  applyForce: ApplyForceMessage
+  applyImpulse: ApplyImpulseMessage
+  applyLocalForce: ApplyLocalForceMessage
+  applyLocalImpulse: ApplyLocalImpulseMessage
+  applyRaycastVehicleEngineForce: ApplyRaycastVehicleEngineForceMessage
+  applyTorque: ApplyTorque
+  disableConstraint: DisableConstraintMessage
+  disableConstraintMotor: DisableConstraintMotorMessage
+  enableConstraint: EnableConstraintMessage
+  enableConstraintMotor: EnableConstraintMotorMessage
+  removeBodies: RemoveBodiesMessage
+  removeConstraint: RemoveConstraintMessage
+  removeContactMaterial: RemoveContactMaterialMessage
+  removeRay: RemoveRayMessage
+  removeRaycastVehicle: RemoveRaycastVehicleMessage
+  removeSpring: RemoveSpringMessage
+  setAllowSleep: AtomicMessage<'allowSleep'>
+  setAngularDamping: AtomicMessage<'angularDamping'>
+  setAngularFactor: VectorMessage
+  setAngularVelocity: VectorMessage
+  setAxisIndex: WorldMessage<'axisIndex'>
+  setBroadphase: WorldMessage<'broadphase'>
+  setCollisionFilterGroup: AtomicMessage<'collisionFilterGroup'>
+  setCollisionFilterMask: AtomicMessage<'collisionFilterMask'>
+  setCollisionResponse: AtomicMessage<'collisionResponse'>
+  setConstraintMotorMaxForce: SetConstraintMotorMaxForce
+  setConstraintMotorSpeed: SetConstraintMotorSpeed
+  setFixedRotation: AtomicMessage<'fixedRotation'>
+  setGravity: WorldMessage<'gravity'>
+  setIsTrigger: AtomicMessage<'isTrigger'>
+  setIterations: WorldMessage<'iterations'>
+  setLinearDamping: AtomicMessage<'linearDamping'>
+  setLinearFactor: VectorMessage
+  setMass: AtomicMessage<'mass'>
+  setMaterial: AtomicMessage<'material'>
+  setPosition: VectorMessage
+  setQuaternion: QuaternionMessage
+  setRaycastVehicleBrake: SetRaycastVehicleBrakeMessage
+  setRaycastVehicleSteeringValue: SetRaycastVehicleSteeringValueMessage
+  setRotation: RotationMessage
+  setSleepSpeedLimit: AtomicMessage<'sleepSpeedLimit'>
+  setSleepTimeLimit: AtomicMessage<'sleepTimeLimit'>
+  setSpringDamping: SetSpringDampingMessage
+  setSpringRestLength: SetSpringRestLengthMessage
+  setSpringStiffness: SetSpringStiffnessMessage
+  setTolerance: WorldMessage<'tolerance'>
+  setUserData: AtomicMessage<'userData'>
+  setVelocity: VectorMessage
+  sleep: SleepMessage
+  subscribe: SubscribeMessage
+  unsubscribe: UnsubscribeMessage
+  wakeUp: WakeUpMessage
+}
+
+export type CannonMessageBody<T extends keyof CannonMessageMap> = Omit<CannonMessageMap[T], 'op'>
+
+export interface CannonWebWorker {
+  onmessage: (e: IncomingWorkerMessage) => void
+  postMessage:
+    | ((message: CannonMessage) => void)
+    | ((message: CannonMessage, transferables?: Transferable[]) => void)
+  terminate: () => void
 }
 
 export type ProviderContext = {
   bodies: MutableRefObject<{ [uuid: string]: number }>
-  buffers: Buffers
   events: CannonEvents
   refs: Refs
   subscriptions: Subscriptions

--- a/src/useUpdateWorldPropsEffect.ts
+++ b/src/useUpdateWorldPropsEffect.ts
@@ -1,7 +1,8 @@
 import { useEffect } from 'react'
 
 import type { ProviderProps } from './Provider'
-import type { CannonWorker, WorldPropName } from './setup'
+import type { WorldPropName } from './setup'
+import type { CannonWorker } from './worker/cannon-worker'
 
 type Props = Pick<Required<ProviderProps>, WorldPropName> & { worker: CannonWorker }
 
@@ -13,9 +14,19 @@ export function useUpdateWorldPropsEffect({
   tolerance,
   worker,
 }: Props) {
-  useEffect(() => void worker.postMessage({ op: 'setAxisIndex', props: axisIndex }), [axisIndex])
-  useEffect(() => void worker.postMessage({ op: 'setBroadphase', props: broadphase }), [broadphase])
-  useEffect(() => void worker.postMessage({ op: 'setGravity', props: gravity }), [gravity])
-  useEffect(() => void worker.postMessage({ op: 'setIterations', props: iterations }), [iterations])
-  useEffect(() => void worker.postMessage({ op: 'setTolerance', props: tolerance }), [tolerance])
+  useEffect(() => {
+    worker.axisIndex = axisIndex
+  }, [axisIndex])
+  useEffect(() => {
+    worker.broadphase = broadphase
+  }, [broadphase])
+  useEffect(() => {
+    worker.gravity = gravity
+  }, [gravity])
+  useEffect(() => {
+    worker.iterations = iterations
+  }, [iterations])
+  useEffect(() => {
+    worker.tolerance = tolerance
+  }, [tolerance])
 }

--- a/src/worker/cannon-worker.ts
+++ b/src/worker/cannon-worker.ts
@@ -1,0 +1,427 @@
+import EventEmitter from 'events'
+
+import type {
+  Broadphase,
+  CannonMessageBody,
+  CannonWebWorker,
+  DefaultContactMaterial,
+  IncomingWorkerMessage,
+  Solver,
+  Triplet,
+} from '../setup'
+// @ts-expect-error Types are not setup for this yet
+import Worker from './worker'
+
+export type CannonWorkerProps = {
+  allowSleep?: boolean
+  axisIndex?: number
+  broadphase?: Broadphase
+  defaultContactMaterial?: DefaultContactMaterial
+  gravity?: Triplet
+  iterations?: number
+  quatNormalizeFast?: boolean
+  quatNormalizeSkip?: number
+  size?: number
+  solver?: Solver
+  tolerance?: number
+}
+
+export class CannonWorker extends EventEmitter {
+  get axisIndex(): number {
+    return this.config.axisIndex
+  }
+
+  set axisIndex(value: number) {
+    this.config.axisIndex = value
+    this.worker.postMessage({ op: 'setAxisIndex', props: value })
+  }
+
+  get broadphase(): Broadphase {
+    return this.config.broadphase
+  }
+
+  set broadphase(value: Broadphase) {
+    this.config.broadphase = value
+    this.worker.postMessage({ op: 'setBroadphase', props: value })
+  }
+
+  get gravity(): Triplet {
+    return this.config.gravity
+  }
+
+  set gravity(value: Triplet) {
+    this.config.gravity = value
+    this.worker.postMessage({ op: 'setGravity', props: value })
+  }
+
+  get iterations(): number {
+    return this.config.iterations
+  }
+
+  set iterations(value: number) {
+    this.config.iterations = value
+    this.worker.postMessage({ op: 'setIterations', props: value })
+  }
+
+  get tolerance(): number {
+    return this.config.tolerance
+  }
+
+  set tolerance(value: number) {
+    this.config.tolerance = value
+    this.worker.postMessage({ op: 'setTolerance', props: value })
+  }
+
+  private buffers: {
+    positions: Float32Array
+    quaternions: Float32Array
+  }
+
+  private config: Required<CannonWorkerProps>
+
+  private worker = new Worker() as CannonWebWorker
+
+  constructor({
+    allowSleep = false,
+    axisIndex = 0,
+    broadphase = 'Naive',
+    defaultContactMaterial = { contactEquationStiffness: 1e6 },
+    gravity = [0, -9.81, 0],
+    iterations = 5,
+    quatNormalizeFast = false,
+    quatNormalizeSkip = 0,
+    size = 1000,
+    solver = 'GS',
+    tolerance = 0.001,
+  }: CannonWorkerProps) {
+    super()
+
+    this.config = {
+      allowSleep,
+      axisIndex,
+      broadphase,
+      defaultContactMaterial,
+      gravity,
+      iterations,
+      quatNormalizeFast,
+      quatNormalizeSkip,
+      size,
+      solver,
+      tolerance,
+    }
+
+    this.buffers = {
+      positions: new Float32Array(size * 3),
+      quaternions: new Float32Array(size * 4),
+    }
+
+    this.worker.onmessage = (message: IncomingWorkerMessage) => {
+      if (message.data.op === 'frame') {
+        this.buffers.positions = message.data.positions
+        this.buffers.quaternions = message.data.quaternions
+        this.emit(message.data.op, message.data)
+        return
+      }
+
+      this.emit(message.data.type, message.data)
+    }
+  }
+
+  addBodies({ props, type, uuid }: CannonMessageBody<'addBodies'>): void {
+    this.worker.postMessage({
+      op: 'addBodies',
+      props,
+      type,
+      uuid,
+    })
+  }
+
+  addConstraint({ props: [refA, refB, optns], type, uuid }: CannonMessageBody<'addConstraint'>): void {
+    this.worker.postMessage({
+      op: 'addConstraint',
+      props: [refA, refB, optns],
+      type,
+      uuid,
+    })
+  }
+
+  addContactMaterial({ props, uuid }: CannonMessageBody<'addContactMaterial'>): void {
+    this.worker.postMessage({
+      op: 'addContactMaterial',
+      props,
+      uuid,
+    })
+  }
+
+  addRay({ props, uuid }: CannonMessageBody<'addRay'>): void {
+    this.worker.postMessage({ op: 'addRay', props, uuid })
+  }
+
+  addRaycastVehicle({
+    props: [chassisBodyUUID, wheelUUIDs, wheelInfos, indexForwardAxis, indexRightAxis, indexUpAxis],
+    uuid,
+  }: CannonMessageBody<'addRaycastVehicle'>): void {
+    this.worker.postMessage({
+      op: 'addRaycastVehicle',
+      props: [chassisBodyUUID, wheelUUIDs, wheelInfos, indexForwardAxis, indexRightAxis, indexUpAxis],
+      uuid,
+    })
+  }
+
+  addSpring({ props: [refA, refB, optns], uuid }: CannonMessageBody<'addSpring'>): void {
+    this.worker.postMessage({
+      op: 'addSpring',
+      props: [refA, refB, optns],
+      uuid,
+    })
+  }
+
+  applyForce({ props, uuid }: CannonMessageBody<'applyForce'>): void {
+    this.worker.postMessage({ op: 'applyForce', props, uuid })
+  }
+
+  applyImpulse({ props, uuid }: CannonMessageBody<'applyImpulse'>): void {
+    this.worker.postMessage({ op: 'applyImpulse', props, uuid })
+  }
+
+  applyLocalForce({ props, uuid }: CannonMessageBody<'applyLocalForce'>): void {
+    this.worker.postMessage({ op: 'applyLocalForce', props, uuid })
+  }
+
+  applyLocalImpulse({ props, uuid }: CannonMessageBody<'applyLocalImpulse'>): void {
+    this.worker.postMessage({ op: 'applyLocalImpulse', props, uuid })
+  }
+
+  applyRaycastVehicleEngineForce({ props, uuid }: CannonMessageBody<'applyRaycastVehicleEngineForce'>): void {
+    this.worker.postMessage({
+      op: 'applyRaycastVehicleEngineForce',
+      props,
+      uuid,
+    })
+  }
+
+  applyTorque({ props, uuid }: CannonMessageBody<'applyTorque'>): void {
+    this.worker.postMessage({ op: 'applyTorque', props, uuid })
+  }
+
+  disableConstraint({ uuid }: CannonMessageBody<'disableConstraint'>): void {
+    this.worker.postMessage({ op: 'disableConstraint', uuid })
+  }
+
+  disableConstraintMotor({ uuid }: CannonMessageBody<'disableConstraintMotor'>): void {
+    this.worker.postMessage({ op: 'disableConstraintMotor', uuid })
+  }
+
+  enableConstraint({ uuid }: CannonMessageBody<'enableConstraint'>): void {
+    this.worker.postMessage({ op: 'enableConstraint', uuid })
+  }
+
+  enableConstraintMotor({ uuid }: CannonMessageBody<'enableConstraintMotor'>): void {
+    this.worker.postMessage({ op: 'enableConstraintMotor', uuid })
+  }
+
+  init(): void {
+    const {
+      allowSleep,
+      axisIndex,
+      broadphase,
+      defaultContactMaterial,
+      gravity,
+      iterations,
+      quatNormalizeFast,
+      quatNormalizeSkip,
+      solver,
+      tolerance,
+    } = this.config
+
+    this.worker.postMessage({
+      op: 'init',
+      props: {
+        allowSleep,
+        axisIndex,
+        broadphase,
+        defaultContactMaterial,
+        gravity,
+        iterations,
+        quatNormalizeFast,
+        quatNormalizeSkip,
+        solver,
+        tolerance,
+      },
+    })
+  }
+
+  removeBodies({ uuid }: CannonMessageBody<'removeBodies'>): void {
+    this.worker.postMessage({ op: 'removeBodies', uuid })
+  }
+
+  removeConstraint({ uuid }: CannonMessageBody<'removeConstraint'>): void {
+    this.worker.postMessage({ op: 'removeConstraint', uuid })
+  }
+
+  removeContactMaterial({ uuid }: CannonMessageBody<'removeContactMaterial'>): void {
+    this.worker.postMessage({
+      op: 'removeContactMaterial',
+      uuid,
+    })
+  }
+
+  removeRay({ uuid }: CannonMessageBody<'removeRay'>): void {
+    this.worker.postMessage({ op: 'removeRay', uuid })
+  }
+
+  removeRaycastVehicle({ uuid }: CannonMessageBody<'removeRaycastVehicle'>): void {
+    this.worker.postMessage({ op: 'removeRaycastVehicle', uuid })
+  }
+
+  removeSpring({ uuid }: CannonMessageBody<'removeSpring'>): void {
+    this.worker.postMessage({ op: 'removeSpring', uuid })
+  }
+
+  setAllowSleep({ props, uuid }: CannonMessageBody<'setAllowSleep'>): void {
+    this.worker.postMessage({ op: 'setAllowSleep', props, uuid })
+  }
+
+  setAngularDamping({ props, uuid }: CannonMessageBody<'setAngularDamping'>): void {
+    this.worker.postMessage({ op: 'setAngularDamping', props, uuid })
+  }
+
+  setAngularFactor({ props, uuid }: CannonMessageBody<'setAngularFactor'>): void {
+    this.worker.postMessage({ op: 'setAngularFactor', props, uuid })
+  }
+
+  setAngularVelocity({ props, uuid }: CannonMessageBody<'setAngularVelocity'>): void {
+    this.worker.postMessage({ op: 'setAngularVelocity', props, uuid })
+  }
+
+  setCollisionFilterGroup({ props, uuid }: CannonMessageBody<'setCollisionFilterGroup'>): void {
+    this.worker.postMessage({ op: 'setCollisionFilterGroup', props, uuid })
+  }
+
+  setCollisionFilterMask({ props, uuid }: CannonMessageBody<'setCollisionFilterMask'>): void {
+    this.worker.postMessage({ op: 'setCollisionFilterMask', props, uuid })
+  }
+
+  setCollisionResponse({ props, uuid }: CannonMessageBody<'setCollisionResponse'>): void {
+    this.worker.postMessage({ op: 'setCollisionResponse', props, uuid })
+  }
+
+  setConstraintMotorMaxForce({ props, uuid }: CannonMessageBody<'setConstraintMotorMaxForce'>): void {
+    this.worker.postMessage({ op: 'setConstraintMotorMaxForce', props, uuid })
+  }
+
+  setConstraintMotorSpeed({ props, uuid }: CannonMessageBody<'setConstraintMotorSpeed'>): void {
+    this.worker.postMessage({ op: 'setConstraintMotorSpeed', props, uuid })
+  }
+
+  setFixedRotation({ props, uuid }: CannonMessageBody<'setFixedRotation'>): void {
+    this.worker.postMessage({ op: 'setFixedRotation', props, uuid })
+  }
+
+  setIsTrigger({ props, uuid }: CannonMessageBody<'setIsTrigger'>): void {
+    this.worker.postMessage({ op: 'setIsTrigger', props, uuid })
+  }
+
+  setLinearDamping({ props, uuid }: CannonMessageBody<'setLinearDamping'>): void {
+    this.worker.postMessage({ op: 'setLinearDamping', props, uuid })
+  }
+
+  setLinearFactor({ props, uuid }: CannonMessageBody<'setLinearFactor'>): void {
+    this.worker.postMessage({ op: 'setLinearFactor', props, uuid })
+  }
+
+  setMass({ props, uuid }: CannonMessageBody<'setMass'>): void {
+    this.worker.postMessage({ op: 'setMass', props, uuid })
+  }
+
+  setMaterial({ props, uuid }: CannonMessageBody<'setMaterial'>): void {
+    this.worker.postMessage({ op: 'setMaterial', props, uuid })
+  }
+
+  setPosition({ props, uuid }: CannonMessageBody<'setPosition'>): void {
+    this.worker.postMessage({ op: 'setPosition', props, uuid })
+  }
+
+  setQuaternion({ props: [x, y, z, w], uuid }: CannonMessageBody<'setQuaternion'>): void {
+    this.worker.postMessage({ op: 'setQuaternion', props: [x, y, z, w], uuid })
+  }
+
+  setRaycastVehicleBrake({ props, uuid }: CannonMessageBody<'setRaycastVehicleBrake'>): void {
+    this.worker.postMessage({ op: 'setRaycastVehicleBrake', props, uuid })
+  }
+
+  setRaycastVehicleSteeringValue({ props, uuid }: CannonMessageBody<'setRaycastVehicleSteeringValue'>): void {
+    this.worker.postMessage({
+      op: 'setRaycastVehicleSteeringValue',
+      props,
+      uuid,
+    })
+  }
+
+  setRotation({ props, uuid }: CannonMessageBody<'setRotation'>): void {
+    this.worker.postMessage({ op: 'setRotation', props, uuid })
+  }
+
+  setSleepSpeedLimit({ props, uuid }: CannonMessageBody<'setSleepSpeedLimit'>): void {
+    this.worker.postMessage({ op: 'setSleepSpeedLimit', props, uuid })
+  }
+
+  setSleepTimeLimit({ props, uuid }: CannonMessageBody<'setSleepTimeLimit'>): void {
+    this.worker.postMessage({ op: 'setSleepTimeLimit', props, uuid })
+  }
+
+  setSpringDamping({ props, uuid }: CannonMessageBody<'setSpringDamping'>): void {
+    this.worker.postMessage({ op: 'setSpringDamping', props, uuid })
+  }
+
+  setSpringRestLength({ props, uuid }: CannonMessageBody<'setSpringRestLength'>): void {
+    this.worker.postMessage({ op: 'setSpringRestLength', props, uuid })
+  }
+
+  setSpringStiffness({ props, uuid }: CannonMessageBody<'setSpringStiffness'>): void {
+    this.worker.postMessage({ op: 'setSpringStiffness', props, uuid })
+  }
+
+  setUserData({ props, uuid }: CannonMessageBody<'setUserData'>): void {
+    this.worker.postMessage({ op: 'setUserData', props, uuid })
+  }
+
+  setVelocity({ props, uuid }: CannonMessageBody<'setVelocity'>): void {
+    this.worker.postMessage({ op: 'setVelocity', props, uuid })
+  }
+
+  sleep({ uuid }: CannonMessageBody<'sleep'>): void {
+    this.worker.postMessage({ op: 'sleep', uuid })
+  }
+
+  step(stepSize: number, dt?: number, maxSubSteps?: number): void {
+    const {
+      buffers: { positions, quaternions },
+    } = this
+
+    if (positions.byteLength === 0 || quaternions.byteLength === 0) {
+      return
+    }
+
+    this.worker.postMessage({ op: 'step', positions, props: { dt, maxSubSteps, stepSize }, quaternions }, [
+      positions.buffer,
+      quaternions.buffer,
+    ])
+  }
+
+  subscribe({ props: { id, target, type }, uuid }: CannonMessageBody<'subscribe'>): void {
+    this.worker.postMessage({ op: 'subscribe', props: { id, target, type }, uuid })
+  }
+
+  terminate(): void {
+    this.worker.terminate()
+  }
+
+  unsubscribe({ props }: CannonMessageBody<'unsubscribe'>): void {
+    this.worker.postMessage({ op: 'unsubscribe', props })
+  }
+
+  wakeUp({ uuid }: CannonMessageBody<'wakeUp'>): void {
+    this.worker.postMessage({ op: 'wakeUp', uuid })
+  }
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -74,7 +74,11 @@ self.onmessage = ({ data: { op, positions, props, quaternions, type, uuid } }) =
       break
     }
     case 'step': {
-      state.world.step(props.stepSize, props.timeSinceLastCalled, props.maxSubSteps)
+      if (!props.dt) {
+        state.world.step(props.stepSize)
+      } else {
+        state.world.step(props.stepSize, props.dt, props.maxSubSteps)
+      }
 
       const numberOfBodies = state.world.bodies.length
       for (let i = 0; i < numberOfBodies; i++) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1863,6 +1863,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"


### PR DESCRIPTION
- NEW: Create API layer `CannonWorker` between hooks and cannon web worker
  - This is a step towards #327 
- Change `Operation` type to support props that are undefined
- Updated eslint rule `typescript-eslint/member-ordering` for better ordering for classes