### PR TITLE
[examples/RaycastVehicle] Use a single keydown/keyup event handler for controls

### DIFF
--- a/examples/src/demos/RaycastVehicle/Vehicle.tsx
+++ b/examples/src/demos/RaycastVehicle/Vehicle.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react'
 import type { Object3D } from 'three'
 
 import { Chassis } from './Chassis'
+import { useControls } from './use-controls'
 import { Wheel } from './Wheel'
 
 export type VehicleProps = Required<Pick<BoxProps, 'angularVelocity' | 'position' | 'rotation'>> & {
@@ -133,34 +134,3 @@ function Vehicle({
 }
 
 export default Vehicle
-
-export function useKeyPress(target: string[], event: (pressed: boolean) => void) {
-  useEffect(() => {
-    const downHandler = ({ key }: KeyboardEvent) => target.indexOf(key) !== -1 && event(true)
-    const upHandler = ({ key }: KeyboardEvent) => target.indexOf(key) !== -1 && event(false)
-    window.addEventListener('keydown', downHandler)
-    window.addEventListener('keyup', upHandler)
-    return () => {
-      window.removeEventListener('keydown', downHandler)
-      window.removeEventListener('keyup', upHandler)
-    }
-  }, [])
-}
-
-export function useControls() {
-  const keys = useRef({
-    backward: false,
-    brake: false,
-    forward: false,
-    left: false,
-    reset: false,
-    right: false,
-  })
-  useKeyPress(['ArrowUp', 'w'], (pressed) => (keys.current.forward = pressed))
-  useKeyPress(['ArrowDown', 's'], (pressed) => (keys.current.backward = pressed))
-  useKeyPress(['ArrowLeft', 'a'], (pressed) => (keys.current.left = pressed))
-  useKeyPress(['ArrowRight', 'd'], (pressed) => (keys.current.right = pressed))
-  useKeyPress([' '], (pressed) => (keys.current.brake = pressed))
-  useKeyPress(['r'], (pressed) => (keys.current.reset = pressed))
-  return keys
-}

--- a/examples/src/demos/RaycastVehicle/use-controls.ts
+++ b/examples/src/demos/RaycastVehicle/use-controls.ts
@@ -1,0 +1,58 @@
+import type { MutableRefObject } from 'react'
+import { useEffect, useRef } from 'react'
+
+function useKeyControls(
+  { current }: MutableRefObject<Record<GameControl, boolean>>,
+  map: Record<KeyCode, GameControl>,
+) {
+  useEffect(() => {
+    const handleKeydown = ({ key }: KeyboardEvent) => {
+      if (!isKeyCode(key)) return
+      current[map[key]] = true
+    }
+    window.addEventListener('keydown', handleKeydown)
+    const handleKeyup = ({ key }: KeyboardEvent) => {
+      if (!isKeyCode(key)) return
+      current[map[key]] = false
+    }
+    window.addEventListener('keyup', handleKeyup)
+    return () => {
+      window.removeEventListener('keydown', handleKeydown)
+      window.removeEventListener('keyup', handleKeyup)
+    }
+  }, [current, map])
+}
+
+const keyControlMap = {
+  ' ': 'brake',
+  ArrowDown: 'backward',
+  ArrowLeft: 'left',
+  ArrowRight: 'right',
+  ArrowUp: 'forward',
+  a: 'left',
+  d: 'right',
+  r: 'reset',
+  s: 'backward',
+  w: 'forward',
+} as const
+
+type KeyCode = keyof typeof keyControlMap
+type GameControl = typeof keyControlMap[KeyCode]
+
+const keyCodes = Object.keys(keyControlMap) as KeyCode[]
+const isKeyCode = (v: unknown): v is KeyCode => keyCodes.includes(v as KeyCode)
+
+export function useControls() {
+  const controls = useRef<Record<GameControl, boolean>>({
+    backward: false,
+    brake: false,
+    forward: false,
+    left: false,
+    reset: false,
+    right: false,
+  })
+
+  useKeyControls(controls, keyControlMap)
+
+  return controls
+}


### PR DESCRIPTION
The previous implementation creates 20 event listeners with 10 firing on each keydown and 10 on each keyup.
