### PR TITLE
Instantiate worker on connect, call it before init inside useEffect

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prettier-fix": "npm run prettier-fix --workspaces",
     "postinstall": "husky install"
   },
+  "type": "module",
   "workspaces": [
     "packages/cannon-worker-api",
     "packages/react-three-cannon",

--- a/packages/cannon-worker-api/src/cannon-worker-api.ts
+++ b/packages/cannon-worker-api/src/cannon-worker-api.ts
@@ -3,6 +3,7 @@ import Worker from 'web-worker:./worker/index.ts'
 
 import type {
   Broadphase,
+  CannonMessage,
   CannonMessageBody,
   CannonWebWorker,
   IncomingWorkerMessage,
@@ -20,7 +21,7 @@ export class CannonWorkerAPI extends EventEmitter {
 
   set axisIndex(value: 0 | 1 | 2) {
     this.config.axisIndex = value
-    this.worker.postMessage({ op: 'setAxisIndex', props: value })
+    this.postMessage({ op: 'setAxisIndex', props: value })
   }
 
   get broadphase(): Broadphase {
@@ -29,7 +30,7 @@ export class CannonWorkerAPI extends EventEmitter {
 
   set broadphase(value: Broadphase) {
     this.config.broadphase = value
-    this.worker.postMessage({ op: 'setBroadphase', props: value })
+    this.postMessage({ op: 'setBroadphase', props: value })
   }
 
   get gravity(): Triplet {
@@ -38,7 +39,7 @@ export class CannonWorkerAPI extends EventEmitter {
 
   set gravity(value: Triplet) {
     this.config.gravity = value
-    this.worker.postMessage({ op: 'setGravity', props: value })
+    this.postMessage({ op: 'setGravity', props: value })
   }
 
   get iterations(): number {
@@ -47,7 +48,7 @@ export class CannonWorkerAPI extends EventEmitter {
 
   set iterations(value: number) {
     this.config.iterations = value
-    this.worker.postMessage({ op: 'setIterations', props: value })
+    this.postMessage({ op: 'setIterations', props: value })
   }
 
   get tolerance(): number {
@@ -56,7 +57,7 @@ export class CannonWorkerAPI extends EventEmitter {
 
   set tolerance(value: number) {
     this.config.tolerance = value
-    this.worker.postMessage({ op: 'setTolerance', props: value })
+    this.postMessage({ op: 'setTolerance', props: value })
   }
 
   private buffers: {
@@ -65,8 +66,8 @@ export class CannonWorkerAPI extends EventEmitter {
   }
 
   private config: Required<CannonWorkerProps>
-
-  private worker = new Worker() as CannonWebWorker
+  private messageQueue: CannonMessage[] = []
+  private worker: CannonWebWorker | null = null
 
   constructor({
     allowSleep = false,
@@ -101,6 +102,87 @@ export class CannonWorkerAPI extends EventEmitter {
       positions: new Float32Array(size * 3),
       quaternions: new Float32Array(size * 4),
     }
+  }
+
+  addBodies({ props, type, uuid }: CannonMessageBody<'addBodies'>): void {
+    this.postMessage({
+      op: 'addBodies',
+      props,
+      type,
+      uuid,
+    })
+  }
+
+  addConstraint({ props: [refA, refB, optns], type, uuid }: CannonMessageBody<'addConstraint'>): void {
+    this.postMessage({
+      op: 'addConstraint',
+      props: [refA, refB, optns],
+      type,
+      uuid,
+    })
+  }
+
+  addContactMaterial({ props, uuid }: CannonMessageBody<'addContactMaterial'>): void {
+    this.postMessage({
+      op: 'addContactMaterial',
+      props,
+      uuid,
+    })
+  }
+
+  addRay({ props, uuid }: CannonMessageBody<'addRay'>): void {
+    this.postMessage({ op: 'addRay', props, uuid })
+  }
+
+  addRaycastVehicle({
+    props: [chassisBodyUUID, wheelUUIDs, wheelInfos, indexForwardAxis, indexRightAxis, indexUpAxis],
+    uuid,
+  }: CannonMessageBody<'addRaycastVehicle'>): void {
+    this.postMessage({
+      op: 'addRaycastVehicle',
+      props: [chassisBodyUUID, wheelUUIDs, wheelInfos, indexForwardAxis, indexRightAxis, indexUpAxis],
+      uuid,
+    })
+  }
+
+  addSpring({ props: [refA, refB, optns], uuid }: CannonMessageBody<'addSpring'>): void {
+    this.postMessage({
+      op: 'addSpring',
+      props: [refA, refB, optns],
+      uuid,
+    })
+  }
+
+  applyForce({ props, uuid }: CannonMessageBody<'applyForce'>): void {
+    this.postMessage({ op: 'applyForce', props, uuid })
+  }
+
+  applyImpulse({ props, uuid }: CannonMessageBody<'applyImpulse'>): void {
+    this.postMessage({ op: 'applyImpulse', props, uuid })
+  }
+
+  applyLocalForce({ props, uuid }: CannonMessageBody<'applyLocalForce'>): void {
+    this.postMessage({ op: 'applyLocalForce', props, uuid })
+  }
+
+  applyLocalImpulse({ props, uuid }: CannonMessageBody<'applyLocalImpulse'>): void {
+    this.postMessage({ op: 'applyLocalImpulse', props, uuid })
+  }
+
+  applyRaycastVehicleEngineForce({ props, uuid }: CannonMessageBody<'applyRaycastVehicleEngineForce'>): void {
+    this.postMessage({
+      op: 'applyRaycastVehicleEngineForce',
+      props,
+      uuid,
+    })
+  }
+
+  applyTorque({ props, uuid }: CannonMessageBody<'applyTorque'>): void {
+    this.postMessage({ op: 'applyTorque', props, uuid })
+  }
+
+  connect(): void {
+    this.worker = new Worker() as CannonWebWorker
 
     this.worker.onmessage = (message: IncomingWorkerMessage) => {
       if (message.data.op === 'frame') {
@@ -112,99 +194,32 @@ export class CannonWorkerAPI extends EventEmitter {
 
       this.emit(message.data.type, message.data)
     }
-  }
 
-  addBodies({ props, type, uuid }: CannonMessageBody<'addBodies'>): void {
-    this.worker.postMessage({
-      op: 'addBodies',
-      props,
-      type,
-      uuid,
-    })
-  }
+    for (const message of this.messageQueue) {
+      this.worker.postMessage(message)
+    }
 
-  addConstraint({ props: [refA, refB, optns], type, uuid }: CannonMessageBody<'addConstraint'>): void {
-    this.worker.postMessage({
-      op: 'addConstraint',
-      props: [refA, refB, optns],
-      type,
-      uuid,
-    })
-  }
-
-  addContactMaterial({ props, uuid }: CannonMessageBody<'addContactMaterial'>): void {
-    this.worker.postMessage({
-      op: 'addContactMaterial',
-      props,
-      uuid,
-    })
-  }
-
-  addRay({ props, uuid }: CannonMessageBody<'addRay'>): void {
-    this.worker.postMessage({ op: 'addRay', props, uuid })
-  }
-
-  addRaycastVehicle({
-    props: [chassisBodyUUID, wheelUUIDs, wheelInfos, indexForwardAxis, indexRightAxis, indexUpAxis],
-    uuid,
-  }: CannonMessageBody<'addRaycastVehicle'>): void {
-    this.worker.postMessage({
-      op: 'addRaycastVehicle',
-      props: [chassisBodyUUID, wheelUUIDs, wheelInfos, indexForwardAxis, indexRightAxis, indexUpAxis],
-      uuid,
-    })
-  }
-
-  addSpring({ props: [refA, refB, optns], uuid }: CannonMessageBody<'addSpring'>): void {
-    this.worker.postMessage({
-      op: 'addSpring',
-      props: [refA, refB, optns],
-      uuid,
-    })
-  }
-
-  applyForce({ props, uuid }: CannonMessageBody<'applyForce'>): void {
-    this.worker.postMessage({ op: 'applyForce', props, uuid })
-  }
-
-  applyImpulse({ props, uuid }: CannonMessageBody<'applyImpulse'>): void {
-    this.worker.postMessage({ op: 'applyImpulse', props, uuid })
-  }
-
-  applyLocalForce({ props, uuid }: CannonMessageBody<'applyLocalForce'>): void {
-    this.worker.postMessage({ op: 'applyLocalForce', props, uuid })
-  }
-
-  applyLocalImpulse({ props, uuid }: CannonMessageBody<'applyLocalImpulse'>): void {
-    this.worker.postMessage({ op: 'applyLocalImpulse', props, uuid })
-  }
-
-  applyRaycastVehicleEngineForce({ props, uuid }: CannonMessageBody<'applyRaycastVehicleEngineForce'>): void {
-    this.worker.postMessage({
-      op: 'applyRaycastVehicleEngineForce',
-      props,
-      uuid,
-    })
-  }
-
-  applyTorque({ props, uuid }: CannonMessageBody<'applyTorque'>): void {
-    this.worker.postMessage({ op: 'applyTorque', props, uuid })
+    this.messageQueue.length = 0
   }
 
   disableConstraint({ uuid }: CannonMessageBody<'disableConstraint'>): void {
-    this.worker.postMessage({ op: 'disableConstraint', uuid })
+    this.postMessage({ op: 'disableConstraint', uuid })
   }
 
   disableConstraintMotor({ uuid }: CannonMessageBody<'disableConstraintMotor'>): void {
-    this.worker.postMessage({ op: 'disableConstraintMotor', uuid })
+    this.postMessage({ op: 'disableConstraintMotor', uuid })
+  }
+
+  disconnect(): void {
+    if (this.worker) this.worker.onmessage = null
   }
 
   enableConstraint({ uuid }: CannonMessageBody<'enableConstraint'>): void {
-    this.worker.postMessage({ op: 'enableConstraint', uuid })
+    this.postMessage({ op: 'enableConstraint', uuid })
   }
 
   enableConstraintMotor({ uuid }: CannonMessageBody<'enableConstraintMotor'>): void {
-    this.worker.postMessage({ op: 'enableConstraintMotor', uuid })
+    this.postMessage({ op: 'enableConstraintMotor', uuid })
   }
 
   init(): void {
@@ -221,7 +236,7 @@ export class CannonWorkerAPI extends EventEmitter {
       tolerance,
     } = this.config
 
-    this.worker.postMessage({
+    this.postMessage({
       op: 'init',
       props: {
         allowSleep,
@@ -239,106 +254,106 @@ export class CannonWorkerAPI extends EventEmitter {
   }
 
   removeBodies({ uuid }: CannonMessageBody<'removeBodies'>): void {
-    this.worker.postMessage({ op: 'removeBodies', uuid })
+    this.postMessage({ op: 'removeBodies', uuid })
   }
 
   removeConstraint({ uuid }: CannonMessageBody<'removeConstraint'>): void {
-    this.worker.postMessage({ op: 'removeConstraint', uuid })
+    this.postMessage({ op: 'removeConstraint', uuid })
   }
 
   removeContactMaterial({ uuid }: CannonMessageBody<'removeContactMaterial'>): void {
-    this.worker.postMessage({
+    this.postMessage({
       op: 'removeContactMaterial',
       uuid,
     })
   }
 
   removeRay({ uuid }: CannonMessageBody<'removeRay'>): void {
-    this.worker.postMessage({ op: 'removeRay', uuid })
+    this.postMessage({ op: 'removeRay', uuid })
   }
 
   removeRaycastVehicle({ uuid }: CannonMessageBody<'removeRaycastVehicle'>): void {
-    this.worker.postMessage({ op: 'removeRaycastVehicle', uuid })
+    this.postMessage({ op: 'removeRaycastVehicle', uuid })
   }
 
   removeSpring({ uuid }: CannonMessageBody<'removeSpring'>): void {
-    this.worker.postMessage({ op: 'removeSpring', uuid })
+    this.postMessage({ op: 'removeSpring', uuid })
   }
 
   setAllowSleep({ props, uuid }: CannonMessageBody<'setAllowSleep'>): void {
-    this.worker.postMessage({ op: 'setAllowSleep', props, uuid })
+    this.postMessage({ op: 'setAllowSleep', props, uuid })
   }
 
   setAngularDamping({ props, uuid }: CannonMessageBody<'setAngularDamping'>): void {
-    this.worker.postMessage({ op: 'setAngularDamping', props, uuid })
+    this.postMessage({ op: 'setAngularDamping', props, uuid })
   }
 
   setAngularFactor({ props, uuid }: CannonMessageBody<'setAngularFactor'>): void {
-    this.worker.postMessage({ op: 'setAngularFactor', props, uuid })
+    this.postMessage({ op: 'setAngularFactor', props, uuid })
   }
 
   setAngularVelocity({ props, uuid }: CannonMessageBody<'setAngularVelocity'>): void {
-    this.worker.postMessage({ op: 'setAngularVelocity', props, uuid })
+    this.postMessage({ op: 'setAngularVelocity', props, uuid })
   }
 
   setCollisionFilterGroup({ props, uuid }: CannonMessageBody<'setCollisionFilterGroup'>): void {
-    this.worker.postMessage({ op: 'setCollisionFilterGroup', props, uuid })
+    this.postMessage({ op: 'setCollisionFilterGroup', props, uuid })
   }
 
   setCollisionFilterMask({ props, uuid }: CannonMessageBody<'setCollisionFilterMask'>): void {
-    this.worker.postMessage({ op: 'setCollisionFilterMask', props, uuid })
+    this.postMessage({ op: 'setCollisionFilterMask', props, uuid })
   }
 
   setCollisionResponse({ props, uuid }: CannonMessageBody<'setCollisionResponse'>): void {
-    this.worker.postMessage({ op: 'setCollisionResponse', props, uuid })
+    this.postMessage({ op: 'setCollisionResponse', props, uuid })
   }
 
   setConstraintMotorMaxForce({ props, uuid }: CannonMessageBody<'setConstraintMotorMaxForce'>): void {
-    this.worker.postMessage({ op: 'setConstraintMotorMaxForce', props, uuid })
+    this.postMessage({ op: 'setConstraintMotorMaxForce', props, uuid })
   }
 
   setConstraintMotorSpeed({ props, uuid }: CannonMessageBody<'setConstraintMotorSpeed'>): void {
-    this.worker.postMessage({ op: 'setConstraintMotorSpeed', props, uuid })
+    this.postMessage({ op: 'setConstraintMotorSpeed', props, uuid })
   }
 
   setFixedRotation({ props, uuid }: CannonMessageBody<'setFixedRotation'>): void {
-    this.worker.postMessage({ op: 'setFixedRotation', props, uuid })
+    this.postMessage({ op: 'setFixedRotation', props, uuid })
   }
 
   setIsTrigger({ props, uuid }: CannonMessageBody<'setIsTrigger'>): void {
-    this.worker.postMessage({ op: 'setIsTrigger', props, uuid })
+    this.postMessage({ op: 'setIsTrigger', props, uuid })
   }
 
   setLinearDamping({ props, uuid }: CannonMessageBody<'setLinearDamping'>): void {
-    this.worker.postMessage({ op: 'setLinearDamping', props, uuid })
+    this.postMessage({ op: 'setLinearDamping', props, uuid })
   }
 
   setLinearFactor({ props, uuid }: CannonMessageBody<'setLinearFactor'>): void {
-    this.worker.postMessage({ op: 'setLinearFactor', props, uuid })
+    this.postMessage({ op: 'setLinearFactor', props, uuid })
   }
 
   setMass({ props, uuid }: CannonMessageBody<'setMass'>): void {
-    this.worker.postMessage({ op: 'setMass', props, uuid })
+    this.postMessage({ op: 'setMass', props, uuid })
   }
 
   setMaterial({ props, uuid }: CannonMessageBody<'setMaterial'>): void {
-    this.worker.postMessage({ op: 'setMaterial', props, uuid })
+    this.postMessage({ op: 'setMaterial', props, uuid })
   }
 
   setPosition({ props, uuid }: CannonMessageBody<'setPosition'>): void {
-    this.worker.postMessage({ op: 'setPosition', props, uuid })
+    this.postMessage({ op: 'setPosition', props, uuid })
   }
 
   setQuaternion({ props: [x, y, z, w], uuid }: CannonMessageBody<'setQuaternion'>): void {
-    this.worker.postMessage({ op: 'setQuaternion', props: [x, y, z, w], uuid })
+    this.postMessage({ op: 'setQuaternion', props: [x, y, z, w], uuid })
   }
 
   setRaycastVehicleBrake({ props, uuid }: CannonMessageBody<'setRaycastVehicleBrake'>): void {
-    this.worker.postMessage({ op: 'setRaycastVehicleBrake', props, uuid })
+    this.postMessage({ op: 'setRaycastVehicleBrake', props, uuid })
   }
 
   setRaycastVehicleSteeringValue({ props, uuid }: CannonMessageBody<'setRaycastVehicleSteeringValue'>): void {
-    this.worker.postMessage({
+    this.postMessage({
       op: 'setRaycastVehicleSteeringValue',
       props,
       uuid,
@@ -346,39 +361,39 @@ export class CannonWorkerAPI extends EventEmitter {
   }
 
   setRotation({ props, uuid }: CannonMessageBody<'setRotation'>): void {
-    this.worker.postMessage({ op: 'setRotation', props, uuid })
+    this.postMessage({ op: 'setRotation', props, uuid })
   }
 
   setSleepSpeedLimit({ props, uuid }: CannonMessageBody<'setSleepSpeedLimit'>): void {
-    this.worker.postMessage({ op: 'setSleepSpeedLimit', props, uuid })
+    this.postMessage({ op: 'setSleepSpeedLimit', props, uuid })
   }
 
   setSleepTimeLimit({ props, uuid }: CannonMessageBody<'setSleepTimeLimit'>): void {
-    this.worker.postMessage({ op: 'setSleepTimeLimit', props, uuid })
+    this.postMessage({ op: 'setSleepTimeLimit', props, uuid })
   }
 
   setSpringDamping({ props, uuid }: CannonMessageBody<'setSpringDamping'>): void {
-    this.worker.postMessage({ op: 'setSpringDamping', props, uuid })
+    this.postMessage({ op: 'setSpringDamping', props, uuid })
   }
 
   setSpringRestLength({ props, uuid }: CannonMessageBody<'setSpringRestLength'>): void {
-    this.worker.postMessage({ op: 'setSpringRestLength', props, uuid })
+    this.postMessage({ op: 'setSpringRestLength', props, uuid })
   }
 
   setSpringStiffness({ props, uuid }: CannonMessageBody<'setSpringStiffness'>): void {
-    this.worker.postMessage({ op: 'setSpringStiffness', props, uuid })
+    this.postMessage({ op: 'setSpringStiffness', props, uuid })
   }
 
   setUserData({ props, uuid }: CannonMessageBody<'setUserData'>): void {
-    this.worker.postMessage({ op: 'setUserData', props, uuid })
+    this.postMessage({ op: 'setUserData', props, uuid })
   }
 
   setVelocity({ props, uuid }: CannonMessageBody<'setVelocity'>): void {
-    this.worker.postMessage({ op: 'setVelocity', props, uuid })
+    this.postMessage({ op: 'setVelocity', props, uuid })
   }
 
   sleep({ uuid }: CannonMessageBody<'sleep'>): void {
-    this.worker.postMessage({ op: 'sleep', uuid })
+    this.postMessage({ op: 'sleep', uuid })
   }
 
   step(props: StepProps): void {
@@ -388,25 +403,31 @@ export class CannonWorkerAPI extends EventEmitter {
 
     if (!positions.byteLength && !quaternions.byteLength) return
 
-    this.worker.postMessage({ op: 'step', positions, props, quaternions }, [
+    this.worker?.postMessage({ op: 'step', positions, props, quaternions }, [
       positions.buffer,
       quaternions.buffer,
     ])
   }
 
   subscribe({ props: { id, target, type }, uuid }: CannonMessageBody<'subscribe'>): void {
-    this.worker.postMessage({ op: 'subscribe', props: { id, target, type }, uuid })
+    this.postMessage({ op: 'subscribe', props: { id, target, type }, uuid })
   }
 
   terminate(): void {
-    this.worker.terminate()
+    this.worker?.terminate()
+    this.worker = null
   }
 
   unsubscribe({ props }: CannonMessageBody<'unsubscribe'>): void {
-    this.worker.postMessage({ op: 'unsubscribe', props })
+    this.postMessage({ op: 'unsubscribe', props })
   }
 
   wakeUp({ uuid }: CannonMessageBody<'wakeUp'>): void {
-    this.worker.postMessage({ op: 'wakeUp', uuid })
+    this.postMessage({ op: 'wakeUp', uuid })
+  }
+
+  private postMessage(message: CannonMessage): void {
+    if (this.worker) return this.worker.postMessage(message)
+    this.messageQueue.push(message)
   }
 }

--- a/packages/cannon-worker-api/src/types.ts
+++ b/packages/cannon-worker-api/src/types.ts
@@ -402,7 +402,7 @@ export type CannonMessageProps<T extends OpName> = CannonMessageMap[T] extends {
 export type CannonMessage = CannonMessageMap[OpName]
 
 export interface CannonWebWorker extends Worker {
-  onmessage: (e: IncomingWorkerMessage) => void
+  onmessage: ((e: IncomingWorkerMessage) => void) | null
   postMessage(message: CannonMessage, transfer: Transferable[]): void
   postMessage(message: CannonMessage, options?: StructuredSerializeOptions): void
   terminate: () => void

--- a/packages/cannon-worker-api/src/worker/index.ts
+++ b/packages/cannon-worker-api/src/worker/index.ts
@@ -30,7 +30,7 @@ const createMaterial = createMaterialFactory(state.materials)
 self.onmessage = ({ data }: { data: CannonMessage }) => {
   switch (data.op) {
     case 'init': {
-      init(state, data.props)
+      init(state.world, data.props)
       break
     }
     case 'step': {
@@ -43,7 +43,9 @@ self.onmessage = ({ data }: { data: CannonMessage }) => {
       break
     }
     case 'removeBodies': {
-      for (let i = 0; i < data.uuid.length; i++) state.world.removeBody(state.bodies[data.uuid[i]])
+      for (let i = 0; i < data.uuid.length; i++) {
+        state.world.removeBody(state.bodies[data.uuid[i]])
+      }
       syncBodies()
       break
     }

--- a/packages/cannon-worker-api/src/worker/operations/init.ts
+++ b/packages/cannon-worker-api/src/worker/operations/init.ts
@@ -2,7 +2,7 @@ import type { Body } from 'cannon-es'
 import { GSSolver, NaiveBroadphase, SAPBroadphase, SplitSolver } from 'cannon-es'
 
 import type { CannonMessageProps } from '../../types'
-import type { State } from '../state'
+import type { DecoratedWorld } from '../state'
 import type { CannonWorkerGlobalScope, WithUUID } from '../types'
 
 declare const self: CannonWorkerGlobalScope
@@ -23,7 +23,7 @@ function emitEndContact({ bodyA, bodyB }: TwoBodies) {
 }
 
 export const init = (
-  state: State,
+  world: DecoratedWorld,
   {
     allowSleep,
     axisIndex = 0,
@@ -36,29 +36,29 @@ export const init = (
     solver,
     tolerance,
   }: CannonMessageProps<'init'>,
-) => {
-  state.world.allowSleep = allowSleep
-  state.world.gravity.set(gravity[0], gravity[1], gravity[2])
-  state.world.quatNormalizeFast = quatNormalizeFast
-  state.world.quatNormalizeSkip = quatNormalizeSkip
+): void => {
+  world.allowSleep = allowSleep
+  world.gravity.set(...gravity)
+  world.quatNormalizeFast = quatNormalizeFast
+  world.quatNormalizeSkip = quatNormalizeSkip
 
   if (solver === 'Split') {
-    state.world.solver = new SplitSolver(new GSSolver())
+    world.solver = new SplitSolver(new GSSolver())
   }
 
-  if (state.world.solver instanceof GSSolver) {
-    state.world.solver.tolerance = tolerance
-    state.world.solver.iterations = iterations
+  if (world.solver instanceof GSSolver) {
+    world.solver.tolerance = tolerance
+    world.solver.iterations = iterations
   }
 
-  state.world.broadphase = broadphase === 'SAP' ? new SAPBroadphase(state.world) : new NaiveBroadphase()
+  world.broadphase = broadphase === 'SAP' ? new SAPBroadphase(world) : new NaiveBroadphase()
 
-  if (state.world.broadphase instanceof SAPBroadphase) {
-    state.world.broadphase.axisIndex = axisIndex
+  if (world.broadphase instanceof SAPBroadphase) {
+    world.broadphase.axisIndex = axisIndex
   }
 
-  state.world.addEventListener('beginContact', emitBeginContact)
-  state.world.addEventListener('endContact', emitEndContact)
+  world.addEventListener('beginContact', emitBeginContact)
+  world.addEventListener('endContact', emitEndContact)
 
-  Object.assign(state.world.defaultContactMaterial, defaultContactMaterial)
+  Object.assign(world.defaultContactMaterial, defaultContactMaterial)
 }

--- a/packages/cannon-worker-api/src/worker/state.ts
+++ b/packages/cannon-worker-api/src/worker/state.ts
@@ -4,7 +4,7 @@ import { World } from 'cannon-es'
 import type { SubscriptionName, SubscriptionTarget } from '../types'
 import type { WithUUID } from './types'
 
-interface DecoratedWorld extends World {
+export interface DecoratedWorld extends World {
   bodies: WithUUID<Body>[]
   constraints: WithUUID<Constraint>[]
   contactmaterials: WithUUID<ContactMaterial>[]

--- a/packages/react-three-cannon/src/physics-provider.tsx
+++ b/packages/react-three-cannon/src/physics-provider.tsx
@@ -10,7 +10,7 @@ import { CannonWorkerAPI } from '@pmndrs/cannon-worker-api'
 import type { RenderCallback } from '@react-three/fiber'
 import { useFrame, useThree } from '@react-three/fiber'
 import type { FC, PropsWithChildren } from 'react'
-import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { Object3D } from 'three'
 import { InstancedMesh, Matrix4, Quaternion, Vector3 } from 'three'
 
@@ -208,7 +208,8 @@ export const PhysicsProvider: FC<PhysicsProviderProps> = ({
   // Otherwise the buffers will be invalidated by the browser
   useFrame(loop)
 
-  useLayoutEffect(() => {
+  useEffect(() => {
+    worker.connect()
     worker.init()
 
     worker.on('collide', collideHandler)


### PR DESCRIPTION
## @pmndrs/cannon-worker-api

- New private method `postMessage` that queues the messages if there is no worker
- New public method: `connect`, we instantiate the worker, add the onmessage handler and flush the messageQueue
- New public method: `disconnect`, removes the onmessage handler (probably unnecessary)
- `init` now takes `world` instead of `state`

## @react-three/cannon

- Now calls `connect` before `init` in a useEffect (instead of useLayoutEffect)