### PR TITLE
Add scaleOverride to useBody props

### DIFF
--- a/packages/react-three-cannon/src/hooks.ts
+++ b/packages/react-three-cannon/src/hooks.ts
@@ -193,6 +193,7 @@ function useBody<B extends BodyProps<unknown[]>>(
             refs[id] = object
             debugApi?.add(id, props, type)
             setupCollision(events, props, id)
+            if (props.scaleOverride) scaleOverrides[uuid[i]] = new Vector3(...props.scaleOverride)
             return { ...props, args: argsFn(props.args) }
           })
         : uuid.map((id, i) => {


### PR DESCRIPTION
Makes it so you can specify`scaleOverride` in the `uesBody` props. Since most use cases I have for this initialize the scale on mount and then don't touch it, this method ends up being more compact and also lets me use the same scale factor in the body easily. For example:

```js
const [ref, { at }] = useBox(() => {
    const scale = randomInRange(0.65, 1.2)
    return {
      args: [size * scale, size * scale, size * scale],
      mass: 1,
      position: [Math.random() - 0.5, Math.random() * 2, Math.random() - 0.5],
      scaleOverride: [scale, scale, scale],
    }
  })
  ```
